### PR TITLE
GCP NLB 보완

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/NLBHandler.go
@@ -2359,13 +2359,17 @@ func (nlbHandler *GCPNLBHandler) addTargetPoolInstance(regionID string, targetPo
 func (nlbHandler *GCPNLBHandler) removeTargetPoolInstances(regionID string, targetPoolName string, deleteInstanceIIDs *[]irs.IID) error {
 	// path param
 	projectID := nlbHandler.Credential.ProjectID
+	zoneID := nlbHandler.Region.Zone
 
 	if deleteInstanceIIDs != nil {
-		// queryParam
 		instanceRequest := compute.TargetPoolsRemoveInstanceRequest{}
 		instanceReferenceList := []*compute.InstanceReference{}
 		for _, instance := range *deleteInstanceIIDs {
-			instanceUrl := instance.SystemId
+			//instanceUrl := instance.SystemId
+			instanceUrl, err := nlbHandler.getVmUrl(zoneID, instance)
+			if err != nil {
+				return err
+			}
 			instanceReference := &compute.InstanceReference{Instance: instanceUrl}
 			instanceReferenceList = append(instanceReferenceList, instanceReference)
 		}


### PR DESCRIPTION
- GCP에서는 url 형태의 Data로 사용되는 resource가 있어
  SP 내부에서는 url 사용이 안되기 때문에 id만 빼서 사용
  . NBL AddVM, RemoveVm 보완