### PR TITLE
[AWS] Recheck the default disk size

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/DiskHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/DiskHandler.go
@@ -528,8 +528,21 @@ func validateCreateDisk(diskReqInfo *irs.DiskInfo) error {
 		for _, diskSizeInfo := range arrDiskSizeOfType {
 			diskSizeArr := strings.Split(diskSizeInfo, "|")
 			if strings.EqualFold(reqDiskType, diskSizeArr[0]) {
-				reqDiskSize = diskSizeArr[1]
-				diskReqInfo.DiskSize = diskSizeArr[1] // set default value
+				diskMinSize, err := strconv.ParseInt(diskSizeArr[1], 10, 64)
+				if err != nil {
+					cblogger.Error(err)
+					return err
+				}
+
+				// default size를 50GB로 정하였으나,
+				// st1, sc1 type의 경우 minimum size가 50GB보다 큰 125GB이므로, 이 경우에는 minimum size를 default size로 사용함
+				if diskMinSize < 50 {
+					reqDiskSize = "50"
+					diskReqInfo.DiskSize = "50"
+				} else {
+					reqDiskSize = diskSizeArr[1]
+					diskReqInfo.DiskSize = diskSizeArr[1] // set default value
+				}
 				break
 			}
 		}


### PR DESCRIPTION
[AWS] Recheck the default disk size

- Disk를 default type과 default size로 생성 시 1GB의 Disk 생성됨
- [Disk and Driver API](https://github.com/cloud-barista/cb-spider/wiki/Disk-and-Driver-API#3-%EB%93%9C%EB%9D%BC%EC%9D%B4%EB%B2%84-%EA%B0%9C%EB%B0%9C-%EB%85%B8%ED%8A%B8) 가이드에 맞추어 default size를 50GB로 변경
- 단, st1, sc1 type의 경우 minimum size가 50GB보다 큰 125GB이므로 , 이 경우에는 minimum size를 default size로 사용