### PR TITLE
PriceInfo AWS filter implementation

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -1751,7 +1751,7 @@ func handlePriceInfo() {
 				// Type : [TERM_CONTAIN, ANY_OF, TERM_MATCH, NONE_OF, CONTAINS, EQUALS]
 				// filterList = append(filterList, irs.KeyValue{Key: "filter", Value: "{\"Field\":\"instanceType\",\"Type\":\"TERM_MATCH\",\"Value\":\"t2.nano\"}"})
 				// filterList = append(filterList, irs.KeyValue{Key: "filter", Value: "{\"Field\":\"operatingSystem\",\"Type\":\"TERM_MATCH\",\"Value\":\"Linux\"}"})
-				filterList = append(filterList, irs.KeyValue{Key: "filter", Value: "{\"Field\":\"sku\",\"Type\":\"TERM_MATCH\",\"Value\":\"24MKFUYR8UGHCNGB\"}"})
+				//filterList = append(filterList, irs.KeyValue{Key: "filter", Value: "{\"Field\":\"sku\",\"Type\":\"TERM_MATCH\",\"Value\":\"24MKFUYR8UGHCNGB\"}"})
 
 				// TEST seraach data
 				// instanceType = t2.nano
@@ -1760,7 +1760,9 @@ func handlePriceInfo() {
 				// cli 에서 아래 명령어를 통해 attribute를 검색할 수 있음.
 				// aws pricing get-attribute-values --service-code AmazonEC2 --attribute-name instanceType
 
-				result, err := handler.GetPriceInfo("AmazonEC2", "ap-northeast-2", filterList)
+				//result, err := handler.GetPriceInfo("AmazonEC2", "ap-northeast-2", filterList)
+				result, err := handler.GetPriceInfo("AmazonEC2", "us-west-1", filterList)
+
 				if err != nil {
 					cblogger.Infof("GetPriceInfo 조회 실패 : ", err)
 				} else {
@@ -1926,6 +1928,8 @@ func readConfigFile() Config {
 	rootPath := os.Getenv("CBSPIDER_PATH")
 	cblogger.Infof("Test Data 설정파일 : [%s]", rootPath+"/config/config.yaml")
 	data, err := ioutil.ReadFile(rootPath + "/config/config.yaml")
+	data, err = ioutil.ReadFile("/Users/mzc01-swy/projects/feature_aws_filter_swy_240130/cloud-control-manager/cloud-driver/drivers/aws/main/Sample/config/config.yaml")
+
 	if err != nil {
 		panic(err)
 	}
@@ -1953,6 +1957,6 @@ func main() {
 	// handleVMSpec()
 	// handleNLB()
 	// handleCluster()
-	// handleRegionZone()
+	//handleRegionZone()
 	handlePriceInfo()
 }

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/CommonHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/CommonHandler.go
@@ -715,14 +715,16 @@ func DescribeRegions(client *ec2.EC2, AllRegionsBool bool, regionName string) (*
 			// AllRegions option to show next 3 status(opt-in-not-required | opted-in | not-opted-in).
 			// true = opt-in-not-required | opted-in | not-opted-in
 			// false = opted-in
-			AllRegions: aws.Bool(AllRegionsBool),
+
+			//AllRegions: aws.Bool(AllRegionsBool),
 		}
 	} else {
 		RegionsInput = &ec2.DescribeRegionsInput{
 			// AllRegions option to show next 3 status(opt-in-not-required | opted-in | not-opted-in).
 			// true = opt-in-not-required | opted-in | not-opted-in
 			// false = opted-in
-			AllRegions: aws.Bool(AllRegionsBool),
+
+			//AllRegions: aws.Bool(AllRegionsBool),
 			RegionNames: []*string{
 				aws.String(regionName), // 여기에 필터로 사용할 Region을 추가합니다.
 			},
@@ -754,12 +756,12 @@ func DescribeAvailabilityZones(client *ec2.EC2, AllRegionsBool bool) (*ec2.Descr
 		ErrorMSG:     "",
 	}
 
-	ZonesInput := &ec2.DescribeAvailabilityZonesInput{
-		AllAvailabilityZones: aws.Bool(AllRegionsBool), //  (true -> for all AZ) | (false -> for all Zone, include not avail )
-	}
-
+	// ZonesInput := &ec2.DescribeAvailabilityZonesInput{
+	// 	AllAvailabilityZones: aws.Bool(AllRegionsBool), //  (true -> for all AZ) | (false -> for all Zone, include not avail )
+	// }
+	// Opt-in 넣으면 credential 에러 -> nil 변경 (20240130)
 	callLogStart := call.Start()
-	respZones, err := client.DescribeAvailabilityZones(ZonesInput)
+	respZones, err := client.DescribeAvailabilityZones(nil) //ZonesInput
 	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
 	callogger.Info(call.String(callLogInfo))
 

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/PriceInfoHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/PriceInfoHandler.go
@@ -3,14 +3,12 @@ package resources
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"strings"
 
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
 	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 
 	"github.com/aws/aws-sdk-go/service/pricing"
 )
@@ -25,67 +23,68 @@ type AwsPriceInfoHandler struct {
 // getPricingClient에 Client *pricing.Pricing 정의
 func (priceInfoHandler *AwsPriceInfoHandler) ListProductFamily(regionName string) ([]string, error) {
 	var result []string
-	input := &pricing.GetAttributeValuesInput{
-		AttributeName: aws.String("productfamily"),
-		MaxResults:    aws.Int64(32), // 2024.01 기준 32개
-		ServiceCode:   aws.String("AmazonEC2"),
-	}
+	result = append(result, "AmazonEC2")
+	// input := &pricing.GetAttributeValuesInput{
+	// 	AttributeName: aws.String("productfamily"),
+	// 	MaxResults:    aws.Int64(32), // 2024.01 기준 32개
+	// 	ServiceCode:   aws.String("AmazonEC2"),
+	// }
 
-	cblogger.Info("input 1321312434242341312312", input)
-	for {
-		attributeValues, err := priceInfoHandler.Client.GetAttributeValues(input)
-		if err != nil {
-			if aerr, ok := err.(awserr.Error); ok {
-				switch aerr.Code() {
-				case pricing.ErrCodeInternalErrorException:
-					cblogger.Error(pricing.ErrCodeInternalErrorException, aerr.Error())
-				case pricing.ErrCodeInvalidParameterException:
-					cblogger.Error(pricing.ErrCodeInvalidParameterException, aerr.Error())
-				case pricing.ErrCodeNotFoundException:
-					cblogger.Error(pricing.ErrCodeNotFoundException, aerr.Error())
-				case pricing.ErrCodeInvalidNextTokenException:
-					cblogger.Error(pricing.ErrCodeInvalidNextTokenException, aerr.Error())
-				case pricing.ErrCodeExpiredNextTokenException:
-					cblogger.Error(pricing.ErrCodeExpiredNextTokenException, aerr.Error())
-				default:
-					cblogger.Error(aerr.Error())
-				}
-			} else {
-				// Prnit the error, cast err to awserr.Error to get the Code and
-				// Message from an error.
-				cblogger.Error(err.Error())
-			}
-		}
+	// cblogger.Info("input 1321312434242341312312", input)
+	// for {
+	// 	attributeValues, err := priceInfoHandler.Client.GetAttributeValues(input)
+	// 	if err != nil {
+	// 		if aerr, ok := err.(awserr.Error); ok {
+	// 			switch aerr.Code() {
+	// 			case pricing.ErrCodeInternalErrorException:
+	// 				cblogger.Error(pricing.ErrCodeInternalErrorException, aerr.Error())
+	// 			case pricing.ErrCodeInvalidParameterException:
+	// 				cblogger.Error(pricing.ErrCodeInvalidParameterException, aerr.Error())
+	// 			case pricing.ErrCodeNotFoundException:
+	// 				cblogger.Error(pricing.ErrCodeNotFoundException, aerr.Error())
+	// 			case pricing.ErrCodeInvalidNextTokenException:
+	// 				cblogger.Error(pricing.ErrCodeInvalidNextTokenException, aerr.Error())
+	// 			case pricing.ErrCodeExpiredNextTokenException:
+	// 				cblogger.Error(pricing.ErrCodeExpiredNextTokenException, aerr.Error())
+	// 			default:
+	// 				cblogger.Error(aerr.Error())
+	// 			}
+	// 		} else {
+	// 			// Prnit the error, cast err to awserr.Error to get the Code and
+	// 			// Message from an error.
+	// 			cblogger.Error(err.Error())
+	// 		}
+	// 	}
 
-		for _, attributeValue := range attributeValues.AttributeValues {
+	// 	for _, attributeValue := range attributeValues.AttributeValues {
 
-			//result = append(result, *attributeValue.Value)
-			result = append(result, *attributeValue.Value)
-		}
+	// 		//result = append(result, *attributeValue.Value)
+	// 		result = append(result, *attributeValue.Value)
+	// 	}
 
-		for i := range attributeValues.AttributeValues {
-			result[i] = removeSpaces(result[i])
-		}
+	// 	for i := range attributeValues.AttributeValues {
+	// 		result[i] = removeSpaces(result[i])
+	// 	}
 
-		for _, attributeValue := range attributeValues.AttributeValues {
-			attributeValue.Value = aws.String(strings.ReplaceAll(*attributeValue.Value, " ", ""))
-		}
+	// 	for _, attributeValue := range attributeValues.AttributeValues {
+	// 		attributeValue.Value = aws.String(strings.ReplaceAll(*attributeValue.Value, " ", ""))
+	// 	}
 
-		// 결과 출력
-		cblogger.Info("rkskekfkekfkekfkekf", attributeValues)
-		fmt.Printf("%+v\n", attributeValues)
+	// 	// 결과 출력
+	// 	cblogger.Info("rkskekfkekfkekfkekf", attributeValues)
+	// 	fmt.Printf("%+v\n", attributeValues)
 
-		cblogger.Info("attributeValue0000000000000000000000000000", attributeValues.AttributeValues)
+	// 	cblogger.Info("attributeValue0000000000000000000000000000", attributeValues.AttributeValues)
 
-		cblogger.Info("attributeValue===============================", result)
-		if attributeValues.NextToken != nil {
-			input = &pricing.GetAttributeValuesInput{
-				NextToken: attributeValues.NextToken,
-			}
-		} else {
-			break
-		}
-	}
+	// 	cblogger.Info("attributeValue===============================", result)
+	// 	if attributeValues.NextToken != nil {
+	// 		input = &pricing.GetAttributeValuesInput{
+	// 			NextToken: attributeValues.NextToken,
+	// 		}
+	// 	} else {
+	// 		break
+	// 	}
+	// }
 
 	return result, nil
 }
@@ -97,53 +96,11 @@ func removeSpaces(s string) string {
 // GetAttributeValues를 통해 AttributeValue를 수집하여 필터로 사용합니다.
 // GetPriceInfo는 DescribeServices를 통해 올바른 productFamily 인자만 검사합니다. -> AttributeName에 오류가 있을경우 빈값을 리턴
 
-var validFilterKey map[string]bool
-
-func init() {
-	validFilterKey = make(map[string]bool, 0)
-
-	refelectValue := reflect.ValueOf(irs.ProductInfo{}) // 구조체의 reflect 값을 가져옴
-
-	for i := 0; i < refelectValue.NumField(); i++ {
-
-		fieldName := refelectValue.Type().Field(i).Name       // 구조체의 필드 이름을 가져옴
-		camelCaseFieldName := toCamelCase(fieldName)          // 필드 이름을 CamelCase로 변환합니다.
-		if _, ok := validFilterKey[camelCaseFieldName]; !ok { // 맵에 이미해당 필드 이름이 존재하지 않으면 맵에 추가
-			validFilterKey[camelCaseFieldName] = true
-		}
-	}
-
-	refelectValue = reflect.ValueOf(irs.PricingPolicies{}) // ris.PricingPolicies 구조체에 동일한 작업 반복
-
-	for i := 0; i < refelectValue.NumField(); i++ {
-
-		fieldName := refelectValue.Type().Field(i).Name
-		camelCaseFieldName := toCamelCase(fieldName)
-		if _, ok := validFilterKey[camelCaseFieldName]; !ok {
-			validFilterKey[camelCaseFieldName] = true
-		}
-	}
-
-	refelectValue = reflect.ValueOf(irs.PricingPolicyInfo{})
-
-	for i := 0; i < refelectValue.NumField(); i++ {
-
-		fieldName := refelectValue.Type().Field(i).Name
-		camelCaseFieldName := toCamelCase(fieldName)
-		if _, ok := validFilterKey[camelCaseFieldName]; !ok {
-			validFilterKey[camelCaseFieldName] = true
-		}
-	}
-
-	fmt.Printf("valid key is this %+v\n", validFilterKey)
-
-}
-func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, regionName string, additionalFilterList []irs.KeyValue) (string, error) {
-	filter, _ := filterListToMap(additionalFilterList)
+func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, regionName string, filterList []irs.KeyValue) (string, error) {
+	priceMap := make(map[string]irs.Price)
 	cblogger.Infof("productFamily======", productFamily)
 
-	cblogger.Infof("filter value : %+v", additionalFilterList)
-
+	cblogger.Infof("filter value : %+v", filterList)
 	describeServicesinput := &pricing.DescribeServicesInput{
 		ServiceCode: aws.String(productFamily),
 		MaxResults:  aws.Int64(1),
@@ -156,62 +113,168 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 		cblogger.Error("No services in given productFamily. CHECK productFamily!")
 		return "", err
 	}
-	// for the test
-	cblogger.Info("services55555555555", services)
+
 	if err != nil {
 		cblogger.Error(err)
 		return "", err
 	}
+	getProductsinputfilters := []*pricing.Filter{}
 
-	//getProductsinputfilters := []*pricing.Filter{}
+	if filterList != nil {
+		for _, filter := range filterList {
+			if filter.Key == "instanceType" {
+				getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
+					Field: aws.String("instanceType"),
+					Type:  aws.String("TERM_MATCH"),
+					Value: aws.String(filter.Value),
+				})
+			}
 
-	// if filterList != nil {
-	// 	for _, filter := range filterList {
-	// 		var getProductsinputfilter pricing.Filter
+			if filter.Key == "operatingSystem" {
+				getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
+					Field: aws.String("operatingSystem"),
+					Type:  aws.String("TERM_MATCH"),
+					Value: aws.String(filter.Value),
+				})
+			}
+			if filter.Key == "vcpu" {
+				getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
+					Field: aws.String("vcpu"),
+					Type:  aws.String("TERM_MATCH"),
+					Value: aws.String(filter.Value),
+				})
+			}
+			if filter.Key == "productId" {
+				getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
+					Field: aws.String("sku"),
+					Type:  aws.String("TERM_MATCH"),
+					Value: aws.String(filter.Value),
+				})
+			}
+			if filter.Key == "memory" {
+				getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
+					Field: aws.String("memory"),
+					Type:  aws.String("TERM_MATCH"),
+					Value: aws.String(filter.Value),
+				})
+			}
+			if filter.Key == "storage" {
+				getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
+					Field: aws.String("storage"),
+					Type:  aws.String("TERM_MATCH"),
+					Value: aws.String(filter.Value),
+				})
+			}
+			if filter.Key == "gpu" {
+				getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
+					Field: aws.String("gpu"),
+					Type:  aws.String("TERM_MATCH"),
+					Value: aws.String(filter.Value),
+				})
+			}
+			if filter.Key == "gpuMemory" {
+				getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
+					Field: aws.String("gpuMemory"),
+					Type:  aws.String("TERM_MATCH"),
+					Value: aws.String(filter.Value),
+				})
+			}
+			if filter.Key == "preInstalledSw" {
+				getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
+					Field: aws.String("preInstalledSw"),
+					Type:  aws.String("TERM_MATCH"),
+					Value: aws.String(filter.Value),
+				})
+			}
+			//price
 
-	// 		err := json.Unmarshal([]byte(filter.Value), &getProductsinputfilter)
-	// 		getProductsinputfilters = append(getProductsinputfilters, &getProductsinputfilter)
+			// if filter.Key == "pricingId" {
+			// 	getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
+			// 		Field: aws.String("priceDimensionsKey"),
+			// 		Type:  aws.String("TERM_MATCH"),
+			// 		Value: aws.String(filter.Value),
+			// 	})
+			// }
 
-	// 		if err != nil {
-	// 			cblogger.Error(err)
-	// 			return "", err
-	// 		}
-	// 		// for the test
-	// 		cblogger.Info("getProductsinputfilter", getProductsinputfilter)
-	// 	}
+			// if filter.Key == "unit" {
+			// 	getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
+			// 		Field: aws.String("unit"),
+			// 		Type:  aws.String("TERM_MATCH"),
+			// 		Value: aws.String(filter.Value),
+			// 	})
+			// }
+			// if filter.Key == "currency" {
+			// 	getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
+			// 		Field: aws.String("currency"),
+			// 		Type:  aws.String("TERM_MATCH"),
+			// 		Value: aws.String(filter.Value),
+			// 	})
+			// }
+			// if filter.Key == "price" {
+			// 	getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
+			// 		Field: aws.String("price"),
+			// 		Type:  aws.String("TERM_MATCH"),
+			// 		Value: aws.String(filter.Value),
+			// 	})
+			// }
+			// if filter.Key == "description" {
+			// 	getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
+			// 		Field: aws.String("description"),
+			// 		Type:  aws.String("TERM_MATCH"),
+			// 		Value: aws.String(filter.Value),
+			// 	})
+			// }
+			// if filter.Key == "leaseContractLength" {
+			// 	getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
+			// 		Field: aws.String("LeaseContractLength"),
+			// 		Type:  aws.String("TERM_MATCH"),
+			// 		Value: aws.String(filter.Value),
+			// 	})
+			// }
+			// if filter.Key == "offeringClass" {
+			// 	getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
+			// 		Field: aws.String("OfferingClass"),
+			// 		Type:  aws.String("TERM_MATCH"),
+			// 		Value: aws.String(filter.Value),
+			// 	})
+			// }
+			// if filter.Key == "purchaseOption" {
+			// 	getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
+			// 		Field: aws.String("preInstalledSw"),
+			// 		Type:  aws.String("TERM_MATCH"),
+			// 		Value: aws.String(filter.Value),
+			// 	})
+			// }
 
-	// 	// for the test
-	// 	cblogger.Info("[]*pricing.Filter{}", []*pricing.Filter{})
-	// }
-	// if regionName != "" {
-	// 	getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
-	// 		Field: aws.String("regionCode"),
-	// 		Type:  aws.String("EQUALS"),
-	// 		Value: aws.String(regionName),
-	// 	})
-	// }
+			//: "filter", Value: "{\"Field\":\"instanceType\",\"Type\":\"TERM_MATCH\",\"Value\":\"t2.nano\"}"})
+			// err := json.Unmarshal([]byte(filter.Value), &getProductsinputfilter)
+			// getProductsinputfilters = append(getProductsinputfilters, &getProductsinputfilter)
 
-	// getProductsinput := &pricing.GetProductsInput{
-	// 	Filters:     getProductsinputfilters,
-	// 	ServiceCode: aws.String(productFamily),
-	// }
-
-	// additionalFilterList []*pricing.Filter로 변환
-	var filters []*pricing.Filter
-
-	for _, kv := range additionalFilterList {
-		filter := &pricing.Filter{
-			Field: aws.String(kv.Key),
-			Value: aws.String(kv.Value),
+			// if err != nil {
+			// 	cblogger.Error(err)
+			// 	return "", err
+			// }
+			// // for the test
+			// cblogger.Info("getProductsinputfilter", getProductsinputfilter)
 		}
-		filters = append(filters, filter)
+
+		// for the test
+		cblogger.Info("[]*pricing.Filter{}", []*pricing.Filter{})
+	}
+	if regionName != "" {
+		getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
+			Field: aws.String("regionCode"),
+			Type:  aws.String("EQUALS"),
+			Value: aws.String(regionName),
+		})
 	}
 
 	getProductsinput := &pricing.GetProductsInput{
-		Filters:     filters,
+		Filters:     getProductsinputfilters,
 		ServiceCode: aws.String(productFamily),
 	}
-
+	// for the test
+	cblogger.Info("getProductsinput", getProductsinput)
 	priceinfos, err := priceInfoHandler.Client.GetProducts(getProductsinput)
 	if err != nil {
 		cblogger.Error(err)
@@ -221,7 +284,7 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 	result := &irs.CloudPriceData{}
 	result.Meta.Version = "v0.1"
 	result.Meta.Description = "Multi-Cloud Price Info"
-
+	cblogger.Info("productInfo", priceinfos)
 	for _, price := range priceinfos.PriceList {
 		jsonString, err := json.MarshalIndent(price["product"].(map[string]interface{})["attributes"], "", "    ")
 		if err != nil {
@@ -235,6 +298,7 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 			cblogger.Error(err)
 		}
 
+		productId := fmt.Sprintf("%s", price["product"].(map[string]interface{})["sku"])
 		productInfo.ProductId = fmt.Sprintf("%s", price["product"].(map[string]interface{})["sku"])
 		productInfo.RegionName = fmt.Sprintf("%s", price["product"].(map[string]interface{})["attributes"].(map[string]interface{})["regionCode"])
 		productInfo.Description = fmt.Sprintf("productFamily= %s, version= %s", price["product"].(map[string]interface{})["productFamily"], price["version"])
@@ -244,11 +308,80 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 		var priceInfo irs.PriceInfo
 		priceInfo.CSPPriceInfo = price["terms"]
 		for termsKey, termsValue := range price["terms"].(map[string]interface{}) {
+			cblogger.Info("termsKey1111111111111111111", termsKey)
+			hasTerm := false
+			termVal := ""
+			hasPriceDimension := false
+			priceDemensionVal := ""
+			hasunit := false
+			unitVal := ""
+			if filterList != nil {
+
+				for _, filter := range filterList {
+					// find filter conditions
+
+					if filter.Key == "pricingPolicy" {
+						hasTerm = true
+						termVal = filter.Value
+						continue
+					}
+
+					if filter.Key == "pricingId" {
+						hasPriceDimension = true
+						priceDemensionVal = filter.Value
+						continue
+					}
+					if filter.Key == "unit" {
+						hasunit = true
+						unitVal = filter.Value
+						continue
+					}
+				}
+				// check filters
+				if hasTerm && termVal != termsKey {
+					continue
+				}
+			}
+
 			for _, policyvalue := range termsValue.(map[string]interface{}) {
+				cblogger.Info("policyvalue333333333333", policyvalue)
 				var pricingPolicy irs.PricingPolicies
 				for innerpolicyKey, innerpolicyValue := range policyvalue.(map[string]interface{}) {
 					if innerpolicyKey == "priceDimensions" {
+						cblogger.Info("innerpolicyKey$$$$$$$$$$$$$$$", innerpolicyKey)
+						cblogger.Info("innerpolicyValue~~~~~~~~~~~~~~~~~~~", innerpolicyValue)
 						for priceDimensionsKey, priceDimensionsValue := range innerpolicyValue.(map[string]interface{}) {
+
+							cblogger.Info("priceDimensionsValue@@@@@@@@@@@@@@@@@@@@@@@", priceDimensionsValue)
+
+							cblogger.Info("filterList==============", filterList)
+
+							if filterList != nil {
+								cblogger.Info("hasPriceDimension**************", hasPriceDimension)
+								cblogger.Info("priceDemensionVal%^&%^&%^&%^&%^&", priceDemensionVal)
+								cblogger.Info("priceDimensionsKey||||||||||||||||", priceDimensionsKey)
+								// check filters
+								if hasPriceDimension && priceDemensionVal != priceDimensionsKey {
+
+									continue
+
+								}
+								cblogger.Info("priceDimensionsKey+++++++++++++++++++", priceDimensionsKey)
+								//pricingId의 unit값이 필터 값으로 들어오면 unit 값을 받은 값으로 설정
+								foundSku := false
+								for _, skukey := range priceDimensionsValue.(map[string]interface{}) {
+									// check filters
+									if hasunit && unitVal == skukey {
+										foundSku = true
+										break
+									}
+								}
+								cblogger.Info("foundSku_+_+_+_+_+_+_+_+_+_+_+_+_+_+", foundSku)
+								if hasunit && !foundSku { // sku를 못 찾았으면 skip.
+									continue
+								}
+							}
+
 							pricingPolicy.PricingId = priceDimensionsKey
 							pricingPolicy.PricingPolicy = termsKey
 							pricingPolicy.Description = fmt.Sprintf("%s", priceDimensionsValue.(map[string]interface{})["description"])
@@ -261,68 +394,33 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 									break
 								}
 							}
-							if filter["productId"] != nil && productInfo.ProductId != *filter["productId"] {
-								continue
-							}
-							if filter["regionName"] != nil && productInfo.RegionName != *filter["regionName"] {
-								continue
-							}
-							if filter["instanceType"] != nil && productInfo.InstanceType != *filter["instanceType"] {
-								continue
-							}
-							if filter["vcpu"] != nil && productInfo.Vcpu != *filter["vcpu"] {
-								continue
-							}
-							if filter["memory"] != nil && productInfo.Memory != *filter["memory"] {
-								continue
-							}
-							if filter["storage"] != nil && productInfo.Storage != *filter["storage"] {
-								continue
-							}
-							if filter["gpu"] != nil && productInfo.Gpu != *filter["gpu"] {
-								continue
-							}
-							if filter["gpuMemory"] != nil && productInfo.GpuMemory != *filter["gpuMemory"] {
-								continue
-							}
-							if filter["operatingSystem"] != nil && productInfo.OperatingSystem != *filter["operatingSystem"] {
-								continue
-							}
-							if filter["preInstalledSw"] != nil && productInfo.PreInstalledSw != *filter["preInstalledSw"] {
-								continue
-							}
-
 							pricingPolicy.Unit = fmt.Sprintf("%s", priceDimensionsValue.(map[string]interface{})["unit"])
 
-							if filter["unit"] != nil && pricingPolicy.Unit != *filter["unit"] {
-								continue
-							}
-							if filter["pricingId"] != nil && pricingPolicy.PricingId != *filter["pricingId"] {
-								continue
-							}
-							if filter["pricingPolicy"] != nil && pricingPolicy.PricingPolicy != *filter["pricingPolicy"] {
-								continue
-							}
-							if filter["currency"] != nil && pricingPolicy.Currency != *filter["currency"] {
-								continue
-							}
-							if filter["price"] != nil && pricingPolicy.Price != *filter["price"] {
-								continue
-							}
-							if filter["description"] != nil && pricingPolicy.Description != *filter["description"] {
-								continue
-							}
-							if filter["leaseContractLength"] != nil && pricingPolicy.PricingPolicyInfo.LeaseContractLength != *filter["leaseContractLength"] {
-								continue
-							}
-							if filter["offeringClass"] != nil && pricingPolicy.PricingPolicyInfo.OfferingClass != *filter["offeringClass"] {
-								continue
-							}
-							if filter["purchaseOption"] != nil && pricingPolicy.PricingPolicyInfo.PurchaseOption != *filter["purchaseOption"] {
-								continue
-							}
+							// priceInfo.PricingPolicies = append(priceInfo.PricingPolicies, pricingPolicy)
+							aPrice, ok := priceMap[productId]
+							cblogger.Info("productId12121212121212121212121212 = ", productId)
+							if ok { // product가 존재하면 policy 추가
+								aPrice.PriceInfo.PricingPolicies = append(aPrice.PriceInfo.PricingPolicies, pricingPolicy)
 
-							priceInfo.PricingPolicies = append(priceInfo.PricingPolicies, pricingPolicy)
+								priceMap[productId] = aPrice
+								cblogger.Info("productId12121212121212121212121212 = ", productId)
+							} else { // product가 없으면 price 추가
+								cblogger.Info("productId12121212121212121212121212 = ", productId)
+								newPriceInfo := irs.PriceInfo{}
+								newPolicies := []irs.PricingPolicies{}
+								newPolicies = append(newPolicies, pricingPolicy)
+
+								newPriceInfo.PricingPolicies = newPolicies
+								// newCSPPriceInfo := []string{}
+								// newCSPPriceInfo = append(newCSPPriceInfo, priceResponseStr)
+								// newPriceInfo.CSPPriceInfo = newCSPPriceInfo
+
+								newPrice := irs.Price{}
+								newPrice.PriceInfo = newPriceInfo
+								newPrice.ProductInfo = productInfo
+
+								priceMap[productId] = newPrice
+							}
 						}
 					}
 				}
@@ -330,14 +428,19 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 		}
 
 		// price info
-		var priceListone irs.Price
-		priceListone.ProductInfo = productInfo
-		priceListone.PriceInfo = priceInfo
+		// var priceListone irs.Price
+		// priceListone.ProductInfo = productInfo
+		// priceListone.PriceInfo = priceInfo
+		priceList := []irs.Price{}
+		for _, value := range priceMap {
+			priceList = append(priceList, value)
+		}
 
 		priceone := irs.CloudPrice{
 			CloudName: "AWS",
 		}
-		priceone.PriceList = append(priceone.PriceList, priceListone)
+		// priceone.PriceList = append(priceone.PriceList, priceList...)
+		priceone.PriceList = priceList
 		result.CloudPriceList = append(result.CloudPriceList, priceone)
 	}
 
@@ -348,160 +451,4 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 	}
 
 	return string(resultString), nil
-}
-
-func toCamelCase(val string) string {
-	if val == "" {
-		return ""
-	}
-
-	return fmt.Sprintf("%s%s", strings.ToLower(val[:1]), val[1:])
-}
-
-func pricePolicyInfoFilter(policy interface{}, filter map[string]*string) bool {
-	if len(filter) == 0 {
-		return false
-	}
-
-	refelectValue := reflect.ValueOf(policy)
-
-	for i := 0; i < refelectValue.NumField(); i++ {
-
-		fieldName := refelectValue.Type().Field(i).Name
-		camelCaseFieldName := toCamelCase(fieldName)
-		fieldValue := refelectValue.Field(i)
-
-		if invalidRefelctCheck(fieldValue) ||
-			fieldValue.Kind() == reflect.Ptr ||
-			fieldValue.Kind() == reflect.Struct {
-			continue
-		}
-
-		fieldStringValue := fmt.Sprintf("%v", fieldValue)
-
-		if value, ok := filter[camelCaseFieldName]; ok {
-			skipFlag := value != nil && *value != fieldStringValue
-			if skipFlag {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
-func priceInfoFilter(policy irs.PricingPolicies, filter map[string]*string) bool {
-	if len(filter) == 0 {
-		return false
-	}
-
-	refelectValue := reflect.ValueOf(policy)
-
-	for i := 0; i < refelectValue.NumField(); i++ {
-		fieldName := refelectValue.Type().Field(i).Name
-		camelCaseFieldName := toCamelCase(fieldName)
-		fieldValue := refelectValue.Field(i)
-
-		if invalidRefelctCheck(fieldValue) ||
-			fieldValue.Kind() == reflect.Struct {
-			continue
-		} else if fieldValue.Kind() == reflect.Ptr {
-
-			derefernceValue := fieldValue.Elem()
-
-			if derefernceValue.Kind() == reflect.Invalid {
-				skipFlag := pricePolicyInfoFilter(irs.PricingPolicyInfo{}, filter)
-				if skipFlag {
-					return true
-				}
-			} else if derefernceValue.Kind() == reflect.Struct {
-				if derefernceValue.Type().Name() == "PricingPolicyInfo" {
-					skipFlag := pricePolicyInfoFilter(*policy.PricingPolicyInfo, filter)
-					if skipFlag {
-						return true
-					}
-				}
-			}
-		}
-
-		fieldStringValue := fmt.Sprintf("%v", fieldValue)
-
-		if value, ok := filter[camelCaseFieldName]; ok {
-			skipFlag := value != nil && *value != fieldStringValue
-			if skipFlag {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
-func invalidRefelctCheck(value reflect.Value) bool {
-	return value.Kind() == reflect.Array ||
-		value.Kind() == reflect.Slice ||
-		value.Kind() == reflect.Map ||
-		value.Kind() == reflect.Func ||
-		value.Kind() == reflect.Interface ||
-		value.Kind() == reflect.UnsafePointer ||
-		value.Kind() == reflect.Chan
-}
-
-func productInfoFilter(productInfo *irs.ProductInfo, filter map[string]*string) bool {
-	if len(filter) == 0 {
-		return false
-	}
-
-	refelectValue := reflect.ValueOf(*productInfo)
-
-	for i := 0; i < refelectValue.NumField(); i++ {
-		fieldName := refelectValue.Type().Field(i).Name
-
-		if fieldName == "CSPProductInfo" || fieldName == "Description" {
-			continue
-		}
-
-		camelCaseFieldName := toCamelCase(fieldName)
-		fieldValue := refelectValue.Field(i)
-
-		if invalidRefelctCheck(fieldValue) ||
-			fieldValue.Kind() == reflect.Ptr ||
-			fieldValue.Kind() == reflect.Struct {
-			continue
-		}
-
-		fieldStringValue := fmt.Sprintf("%v", fieldValue)
-
-		if value, ok := filter[camelCaseFieldName]; ok {
-			skipFlag := value != nil && *value != fieldStringValue
-
-			if skipFlag {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-func filterListToMap(additionalFilterList []irs.KeyValue) (map[string]*string, bool) { // 키-값 목록을 받아서 필터링 된 맵과 유효성 검사 결과 반환
-	filterMap := make(map[string]*string, 0) // 빈 맵 생성
-
-	if additionalFilterList == nil { // 입력값이 nil이면 빈 맵과 true를 반환합니다.
-		return filterMap, true
-	}
-
-	for _, kv := range additionalFilterList { // 각 키-값 쌍에 대해 다음 작업 수행
-		if _, ok := validFilterKey[kv.Key]; !ok { // 키가 유효한 필터 키 목록에 존재하지 않으면 빈 맵과 false를 반환합니다.
-			return map[string]*string{}, false
-		}
-
-		value := strings.TrimSpace(kv.Value) // 값의 앞뒤 공백을 제거합니다.
-		if value == "" {                     // 값이 빈 문자열이면 다음 키-값 쌍으로 넘어갑니다.
-			continue
-		}
-
-		filterMap[kv.Key] = &value // 맵에 키와 값을 저장합니다.
-	}
-
-	return filterMap, true // 필터링된 맵과 true를 반환합니다.
 }

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/PriceInfoHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/PriceInfoHandler.go
@@ -265,14 +265,14 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 			hasunit := false
 			unitVal := ""
 
-			// hasLeaseContractLength := false
-			// LeaseContractLengthVal := ""
+			hasLeaseContractLength := false
+			LeaseContractLengthVal := ""
 
-			// hasOfferingClass := false
-			// OfferingClassVal := ""
+			hasOfferingClass := false
+			OfferingClassVal := ""
 
-			// hasPurchaseOption := false
-			// PurchaseOptionVal := ""
+			hasPurchaseOption := false
+			PurchaseOptionVal := ""
 
 			if filterList != nil {
 
@@ -294,21 +294,21 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 						unitVal = filter.Value
 						continue
 					}
-					// if filter.Key == "LeaseContractLength" {
-					// 	hasLeaseContractLength = true
-					// 	LeaseContractLengthVal = filter.Value
-					// 	continue
-					// }
-					// if filter.Key == "OfferingClass" {
-					// 	hasOfferingClass = true
-					// 	OfferingClassVal = filter.Value
-					// 	continue
-					// }
-					// if filter.Key == "PurchaseOption" {
-					// 	hasPurchaseOption = true
-					// 	PurchaseOptionVal = filter.Value
-					// 	continue
-					// }
+					if filter.Key == "LeaseContractLength" {
+						hasLeaseContractLength = true
+						LeaseContractLengthVal = filter.Value
+						continue
+					}
+					if filter.Key == "OfferingClass" {
+						hasOfferingClass = true
+						OfferingClassVal = filter.Value
+						continue
+					}
+					if filter.Key == "PurchaseOption" {
+						hasPurchaseOption = true
+						PurchaseOptionVal = filter.Value
+						continue
+					}
 				}
 				// check filters
 				if hasTerm && termVal != termsKey {
@@ -325,6 +325,7 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 					cblogger.Info("innerpolicyKey ??????????", innerpolicyKey)                      // termAttribute
 					cblogger.Info("innerpolicyValue !!!!!!!!!!", innerpolicyValue)                  // map
 
+					filterResult := false// true면 전부 filter 된 것임.
 					if innerpolicyKey == "priceDimensions" {
 						for priceDimensionsKey, priceDimensionsValue := range innerpolicyValue.(map[string]interface{}) {
 							cblogger.Info("priceDimensionsValue))))))))))))", priceDimensionsValue)
@@ -368,93 +369,100 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 							}
 							pricingPolicy.Unit = fmt.Sprintf("%s", priceDimensionsValue.(map[string]interface{})["unit"])
 
-							// var cspPriceInfo []string
+							// 기존 로직에서 price add하던 부분
+							// 여기까지 왔으면 filterResult를 완료(true)로 바꿈
+							filterResult = true
 
-							// // Convert the []interface{} to []string before appending
-							// for _, item := range price["terms"].([]interface{}) {
-							// 	jsonString, err := json.Marshal(item)
-							// 	if err != nil {
-							// 		cblogger.Error(err)
-							// 		continue
-							// 	}
-							// 	cspPriceInfo = append(cspPriceInfo, string(jsonString))
-							// }
-							//priceInfo.PricingPolicies = append(priceInfo.PricingPolicies, pricingPolicy)
-
-							aPrice, ok := priceMap[productId]
-
-							if ok { // product가 존재하면 policy 추가
-								cblogger.Info("product exist ", productId)
-								aPrice.PriceInfo.PricingPolicies = append(aPrice.PriceInfo.PricingPolicies, pricingPolicy)
-								// aPrice.PriceInfo.CSPPriceInfo = append(aPrice.PriceInfo.CSPPriceInfo.([]string), cspPriceInfo...)
-								// var priceInfo irs.PriceInfo
-								// priceInfo.CSPPriceInfo = price["terms"]
-								priceMap[productId] = aPrice
-
-							} else { // product가 없으면 price 추가
-								cblogger.Info("product not exist ", productId)
-
-								newPriceInfo := irs.PriceInfo{}
-								newPolicies := []irs.PricingPolicies{}
-								newPolicies = append(newPolicies, pricingPolicy)
-
-								newPriceInfo.PricingPolicies = newPolicies
-								newPriceInfo.CSPPriceInfo = price["terms"] // 새로운 가격이면 terms아래값을 넣는다.
-
-								// newCSPPriceInfo := []string{}
-								// newCSPPriceInfo = append(newCSPPriceInfo, priceResponseStr)
-								// newPriceInfo.CSPPriceInfo = newCSPPriceIn
-								newPrice := irs.Price{}
-								newPrice.PriceInfo = newPriceInfo
-								newPrice.ProductInfo = productInfo
-
-								priceMap[productId] = newPrice
-							}
 						}
 					}
-					// if innerpolicyKey == "termAttributes" {
-					// 	for termAttributeskey, termAttributesValue := range innerpolicyValue.(map[string]interface{}) {
-					// 		cblogger.Info("termAttributeskey********", termAttributeskey)
-					// 		cblogger.Info("termAttributesValue////////", termAttributesValue)
-					// 		if filterList != nil {
 
-					// 			foundSku := false
-					// 			for _, skukey := range termAttributesValue.(map[string]interface{}) {
-					// 				// check filters
-					// 				if hasLeaseContractLength && LeaseContractLengthVal == skukey {
-					// 					foundSku = true
-					// 					break
-					// 				}
-					// 				if hasOfferingClass && OfferingClassVal == skukey {
-					// 					foundSku = true
-					// 					break
-					// 				}
-					// 				if hasPurchaseOption && PurchaseOptionVal == skukey {
-					// 					foundSku = true
-					// 					break
-					// 				}
-					// 			}
-					// 			if hasLeaseContractLength && !foundSku { // sku를 못 찾았으면 skip.
-					// 				cblogger.Info("filtered by Sku ", hasLeaseContractLength, foundSku)
-					// 				continue
-					// 			}
-					// 			if hasOfferingClass && !foundSku { // sku를 못 찾았으면 skip.
-					// 				cblogger.Info("filtered by Sku ", hasOfferingClass, foundSku)
-					// 				continue
-					// 			}
-					// 			if hasPurchaseOption && !foundSku { // sku를 못 찾았으면 skip.
-					// 				cblogger.Info("filtered by Sku ", hasPurchaseOption, foundSku)
-					// 				continue
-					// 			}
-					// 		}
+					if !filterResult {
+						continue // filter걸린게 있으면 filterResult가 false로 유지되었을 것임
+					}
+
+					filterResult = false // 다시 조건시작 
+
+					// leaseContractLength, offeringClass,purchaseOption 필터 추가
+					if innerpolicyKey == "termAttributes" {
+						for termAttributeskey, termAttributesValue := range innerpolicyValue.(map[string]interface{}) {
+							cblogger.Info("termAttributeskey********", termAttributeskey)
+							cblogger.Info("termAttributesValue////////", termAttributesValue)
+							if filterList != nil {
+
+								foundSku := false
+								for _, skukey := range termAttributesValue.(map[string]interface{}) {
+									// check filters
+									if hasLeaseContractLength && LeaseContractLengthVal == skukey {
+										foundSku = true
+										break
+									}
+									if hasOfferingClass && OfferingClassVal == skukey {
+										foundSku = true
+										break
+									}
+									if hasPurchaseOption && PurchaseOptionVal == skukey {
+										foundSku = true
+										break
+									}
+								}
+								if hasLeaseContractLength && !foundSku { // sku를 못 찾았으면 skip.
+									cblogger.Info("filtered by Sku ", hasLeaseContractLength, foundSku)
+									continue
+								}
+								if hasOfferingClass && !foundSku { // sku를 못 찾았으면 skip.
+									cblogger.Info("filtered by Sku ", hasOfferingClass, foundSku)
+									continue
+								}
+								if hasPurchaseOption && !foundSku { // sku를 못 찾았으면 skip.
+									cblogger.Info("filtered by Sku ", hasPurchaseOption, foundSku)
+									continue
+								}
+							}
 					// 		spew.Dump("termAttributesValue.(map[string]interface{})[LeaseContractLength]5555555555", termAttributesValue.(map[string]interface{})["LeaseContractLength"])
 					// 		spew.Dump("termAttributesValue6666666666", termAttributesValue)
-					// 		// pricingPolicy.PricingPolicyInfo.LeaseContractLength = fmt.Sprintf("%s", termAttributesValue.(map[string]interface{})["LeaseContractLength"])
-					// 		// pricingPolicy.PricingPolicyInfo.OfferingClass = fmt.Sprint("%s", innerpolicyValue.(map[string]interface{})["OfferingClass"])
-					// 		// pricingPolicy.PricingPolicyInfo.PurchaseOption = fmt.Sprint("%s", innerpolicyValue.(map[string]interface{})["PurchaseOption"])
-					// 	}
-					// 	cblogger.Info("LeaseContractLength !@!@!@!@!@", pricingPolicy.PricingPolicyInfo.LeaseContractLength)
-					// }
+							pricingPolicy.PricingPolicyInfo.LeaseContractLength = fmt.Sprintf("%s", termAttributesValue.(map[string]interface{})["LeaseContractLength"])
+							pricingPolicy.PricingPolicyInfo.OfferingClass = fmt.Sprint("%s", innerpolicyValue.(map[string]interface{})["OfferingClass"])
+							pricingPolicy.PricingPolicyInfo.PurchaseOption = fmt.Sprint("%s", innerpolicyValue.(map[string]interface{})["PurchaseOption"])
+
+							filterResult = true // 여기까지 왔으면 filterResult를 완료(true)로 바꿈
+						}
+						cblogger.Info("LeaseContractLength !@!@!@!@!@", pricingPolicy.PricingPolicyInfo.LeaseContractLength)
+					}
+
+					if !filterResult {
+						continue // filter걸린게 있으면 filterResult가 false로 유지되었을 것임
+					}
+
+					aPrice, ok := priceMap[productId]
+
+					if ok { // product가 존재하면 policy 추가
+						cblogger.Info("product exist ", productId)
+						aPrice.PriceInfo.PricingPolicies = append(aPrice.PriceInfo.PricingPolicies, pricingPolicy)
+						// aPrice.PriceInfo.CSPPriceInfo = append(aPrice.PriceInfo.CSPPriceInfo.([]string), cspPriceInfo...)
+						// var priceInfo irs.PriceInfo
+						// priceInfo.CSPPriceInfo = price["terms"]
+						priceMap[productId] = aPrice
+
+					} else { // product가 없으면 price 추가
+						cblogger.Info("product not exist ", productId)
+
+						newPriceInfo := irs.PriceInfo{}
+						newPolicies := []irs.PricingPolicies{}
+						newPolicies = append(newPolicies, pricingPolicy)
+
+						newPriceInfo.PricingPolicies = newPolicies
+						newPriceInfo.CSPPriceInfo = price["terms"] // 새로운 가격이면 terms아래값을 넣는다.
+
+						// newCSPPriceInfo := []string{}
+						// newCSPPriceInfo = append(newCSPPriceInfo, priceResponseStr)
+						// newPriceInfo.CSPPriceInfo = newCSPPriceIn
+						newPrice := irs.Price{}
+						newPrice.PriceInfo = newPriceInfo
+						newPrice.ProductInfo = productInfo
+
+						priceMap[productId] = newPrice
+					}
+
 				}
 			}
 		}

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/PriceInfoHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/PriceInfoHandler.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
+	"strings"
 
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
 	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
@@ -28,6 +30,8 @@ func (priceInfoHandler *AwsPriceInfoHandler) ListProductFamily(regionName string
 		MaxResults:    aws.Int64(32), // 2024.01 기준 32개
 		ServiceCode:   aws.String("AmazonEC2"),
 	}
+
+	cblogger.Info("input 1321312434242341312312", input)
 	for {
 		attributeValues, err := priceInfoHandler.Client.GetAttributeValues(input)
 		if err != nil {
@@ -52,9 +56,28 @@ func (priceInfoHandler *AwsPriceInfoHandler) ListProductFamily(regionName string
 				cblogger.Error(err.Error())
 			}
 		}
+
 		for _, attributeValue := range attributeValues.AttributeValues {
+
+			//result = append(result, *attributeValue.Value)
 			result = append(result, *attributeValue.Value)
 		}
+
+		for i := range attributeValues.AttributeValues {
+			result[i] = removeSpaces(result[i])
+		}
+
+		for _, attributeValue := range attributeValues.AttributeValues {
+			attributeValue.Value = aws.String(strings.ReplaceAll(*attributeValue.Value, " ", ""))
+		}
+
+		// 결과 출력
+		cblogger.Info("rkskekfkekfkekfkekf", attributeValues)
+		fmt.Printf("%+v\n", attributeValues)
+
+		cblogger.Info("attributeValue0000000000000000000000000000", attributeValues.AttributeValues)
+
+		cblogger.Info("attributeValue===============================", result)
 		if attributeValues.NextToken != nil {
 			input = &pricing.GetAttributeValuesInput{
 				NextToken: attributeValues.NextToken,
@@ -66,49 +89,126 @@ func (priceInfoHandler *AwsPriceInfoHandler) ListProductFamily(regionName string
 
 	return result, nil
 }
+func removeSpaces(s string) string {
+	return strings.ReplaceAll(s, " ", "")
+}
 
 // AWS에서는 ListProductFamily를 통해 ProductFamily와 AttributeName을 수집하고,
 // GetAttributeValues를 통해 AttributeValue를 수집하여 필터로 사용합니다.
-// GetPriceInfo는 DescribeServices를 통해 옳바른 productFamily 인자만 검사합니다. -> AttributeName에 오류가 있을경우 빈값을 리턴
-func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, regionName string, filterList []irs.KeyValue) (string, error) {
+// GetPriceInfo는 DescribeServices를 통해 올바른 productFamily 인자만 검사합니다. -> AttributeName에 오류가 있을경우 빈값을 리턴
+
+var validFilterKey map[string]bool
+
+func init() {
+	validFilterKey = make(map[string]bool, 0)
+
+	refelectValue := reflect.ValueOf(irs.ProductInfo{}) // 구조체의 reflect 값을 가져옴
+
+	for i := 0; i < refelectValue.NumField(); i++ {
+
+		fieldName := refelectValue.Type().Field(i).Name       // 구조체의 필드 이름을 가져옴
+		camelCaseFieldName := toCamelCase(fieldName)          // 필드 이름을 CamelCase로 변환합니다.
+		if _, ok := validFilterKey[camelCaseFieldName]; !ok { // 맵에 이미해당 필드 이름이 존재하지 않으면 맵에 추가
+			validFilterKey[camelCaseFieldName] = true
+		}
+	}
+
+	refelectValue = reflect.ValueOf(irs.PricingPolicies{}) // ris.PricingPolicies 구조체에 동일한 작업 반복
+
+	for i := 0; i < refelectValue.NumField(); i++ {
+
+		fieldName := refelectValue.Type().Field(i).Name
+		camelCaseFieldName := toCamelCase(fieldName)
+		if _, ok := validFilterKey[camelCaseFieldName]; !ok {
+			validFilterKey[camelCaseFieldName] = true
+		}
+	}
+
+	refelectValue = reflect.ValueOf(irs.PricingPolicyInfo{})
+
+	for i := 0; i < refelectValue.NumField(); i++ {
+
+		fieldName := refelectValue.Type().Field(i).Name
+		camelCaseFieldName := toCamelCase(fieldName)
+		if _, ok := validFilterKey[camelCaseFieldName]; !ok {
+			validFilterKey[camelCaseFieldName] = true
+		}
+	}
+
+	fmt.Printf("valid key is this %+v\n", validFilterKey)
+
+}
+func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, regionName string, additionalFilterList []irs.KeyValue) (string, error) {
+	filter, _ := filterListToMap(additionalFilterList)
+	cblogger.Infof("productFamily======", productFamily)
+
+	cblogger.Infof("filter value : %+v", additionalFilterList)
 
 	describeServicesinput := &pricing.DescribeServicesInput{
 		ServiceCode: aws.String(productFamily),
 		MaxResults:  aws.Int64(1),
 	}
+
+	cblogger.Info("describeServicesinput", describeServicesinput)
+
 	services, err := priceInfoHandler.Client.DescribeServices(describeServicesinput)
 	if services == nil {
 		cblogger.Error("No services in given productFamily. CHECK productFamily!")
 		return "", err
 	}
+	// for the test
+	cblogger.Info("services55555555555", services)
 	if err != nil {
 		cblogger.Error(err)
 		return "", err
 	}
 
-	getProductsinputfilters := []*pricing.Filter{}
+	//getProductsinputfilters := []*pricing.Filter{}
 
-	if filterList != nil {
-		for _, filter := range filterList {
-			var getProductsinputfilter pricing.Filter
-			err := json.Unmarshal([]byte(filter.Value), &getProductsinputfilter)
-			getProductsinputfilters = append(getProductsinputfilters, &getProductsinputfilter)
-			if err != nil {
-				cblogger.Error(err)
-				return "", err
-			}
+	// if filterList != nil {
+	// 	for _, filter := range filterList {
+	// 		var getProductsinputfilter pricing.Filter
+
+	// 		err := json.Unmarshal([]byte(filter.Value), &getProductsinputfilter)
+	// 		getProductsinputfilters = append(getProductsinputfilters, &getProductsinputfilter)
+
+	// 		if err != nil {
+	// 			cblogger.Error(err)
+	// 			return "", err
+	// 		}
+	// 		// for the test
+	// 		cblogger.Info("getProductsinputfilter", getProductsinputfilter)
+	// 	}
+
+	// 	// for the test
+	// 	cblogger.Info("[]*pricing.Filter{}", []*pricing.Filter{})
+	// }
+	// if regionName != "" {
+	// 	getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
+	// 		Field: aws.String("regionCode"),
+	// 		Type:  aws.String("EQUALS"),
+	// 		Value: aws.String(regionName),
+	// 	})
+	// }
+
+	// getProductsinput := &pricing.GetProductsInput{
+	// 	Filters:     getProductsinputfilters,
+	// 	ServiceCode: aws.String(productFamily),
+	// }
+
+	// additionalFilterList []*pricing.Filter로 변환
+	var filters []*pricing.Filter
+
+	for _, kv := range additionalFilterList {
+		filter := &pricing.Filter{
+			Field: aws.String(kv.Key),
+			Value: aws.String(kv.Value),
 		}
-	}
-	if regionName != "" {
-		getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
-			Field: aws.String("regionCode"),
-			Type:  aws.String("EQUALS"),
-			Value: aws.String(regionName),
-		})
+		filters = append(filters, filter)
 	}
 
 	getProductsinput := &pricing.GetProductsInput{
-		Filters:     getProductsinputfilters,
+		Filters:     filters,
 		ServiceCode: aws.String(productFamily),
 	}
 
@@ -161,13 +261,74 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 									break
 								}
 							}
+							if filter["productId"] != nil && productInfo.ProductId != *filter["productId"] {
+								continue
+							}
+							if filter["regionName"] != nil && productInfo.RegionName != *filter["regionName"] {
+								continue
+							}
+							if filter["instanceType"] != nil && productInfo.InstanceType != *filter["instanceType"] {
+								continue
+							}
+							if filter["vcpu"] != nil && productInfo.Vcpu != *filter["vcpu"] {
+								continue
+							}
+							if filter["memory"] != nil && productInfo.Memory != *filter["memory"] {
+								continue
+							}
+							if filter["storage"] != nil && productInfo.Storage != *filter["storage"] {
+								continue
+							}
+							if filter["gpu"] != nil && productInfo.Gpu != *filter["gpu"] {
+								continue
+							}
+							if filter["gpuMemory"] != nil && productInfo.GpuMemory != *filter["gpuMemory"] {
+								continue
+							}
+							if filter["operatingSystem"] != nil && productInfo.OperatingSystem != *filter["operatingSystem"] {
+								continue
+							}
+							if filter["preInstalledSw"] != nil && productInfo.PreInstalledSw != *filter["preInstalledSw"] {
+								continue
+							}
+
 							pricingPolicy.Unit = fmt.Sprintf("%s", priceDimensionsValue.(map[string]interface{})["unit"])
+
+							if filter["unit"] != nil && pricingPolicy.Unit != *filter["unit"] {
+								continue
+							}
+							if filter["pricingId"] != nil && pricingPolicy.PricingId != *filter["pricingId"] {
+								continue
+							}
+							if filter["pricingPolicy"] != nil && pricingPolicy.PricingPolicy != *filter["pricingPolicy"] {
+								continue
+							}
+							if filter["currency"] != nil && pricingPolicy.Currency != *filter["currency"] {
+								continue
+							}
+							if filter["price"] != nil && pricingPolicy.Price != *filter["price"] {
+								continue
+							}
+							if filter["description"] != nil && pricingPolicy.Description != *filter["description"] {
+								continue
+							}
+							if filter["leaseContractLength"] != nil && pricingPolicy.PricingPolicyInfo.LeaseContractLength != *filter["leaseContractLength"] {
+								continue
+							}
+							if filter["offeringClass"] != nil && pricingPolicy.PricingPolicyInfo.OfferingClass != *filter["offeringClass"] {
+								continue
+							}
+							if filter["purchaseOption"] != nil && pricingPolicy.PricingPolicyInfo.PurchaseOption != *filter["purchaseOption"] {
+								continue
+							}
+
 							priceInfo.PricingPolicies = append(priceInfo.PricingPolicies, pricingPolicy)
 						}
 					}
 				}
 			}
 		}
+
 		// price info
 		var priceListone irs.Price
 		priceListone.ProductInfo = productInfo
@@ -187,4 +348,160 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 	}
 
 	return string(resultString), nil
+}
+
+func toCamelCase(val string) string {
+	if val == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("%s%s", strings.ToLower(val[:1]), val[1:])
+}
+
+func pricePolicyInfoFilter(policy interface{}, filter map[string]*string) bool {
+	if len(filter) == 0 {
+		return false
+	}
+
+	refelectValue := reflect.ValueOf(policy)
+
+	for i := 0; i < refelectValue.NumField(); i++ {
+
+		fieldName := refelectValue.Type().Field(i).Name
+		camelCaseFieldName := toCamelCase(fieldName)
+		fieldValue := refelectValue.Field(i)
+
+		if invalidRefelctCheck(fieldValue) ||
+			fieldValue.Kind() == reflect.Ptr ||
+			fieldValue.Kind() == reflect.Struct {
+			continue
+		}
+
+		fieldStringValue := fmt.Sprintf("%v", fieldValue)
+
+		if value, ok := filter[camelCaseFieldName]; ok {
+			skipFlag := value != nil && *value != fieldStringValue
+			if skipFlag {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func priceInfoFilter(policy irs.PricingPolicies, filter map[string]*string) bool {
+	if len(filter) == 0 {
+		return false
+	}
+
+	refelectValue := reflect.ValueOf(policy)
+
+	for i := 0; i < refelectValue.NumField(); i++ {
+		fieldName := refelectValue.Type().Field(i).Name
+		camelCaseFieldName := toCamelCase(fieldName)
+		fieldValue := refelectValue.Field(i)
+
+		if invalidRefelctCheck(fieldValue) ||
+			fieldValue.Kind() == reflect.Struct {
+			continue
+		} else if fieldValue.Kind() == reflect.Ptr {
+
+			derefernceValue := fieldValue.Elem()
+
+			if derefernceValue.Kind() == reflect.Invalid {
+				skipFlag := pricePolicyInfoFilter(irs.PricingPolicyInfo{}, filter)
+				if skipFlag {
+					return true
+				}
+			} else if derefernceValue.Kind() == reflect.Struct {
+				if derefernceValue.Type().Name() == "PricingPolicyInfo" {
+					skipFlag := pricePolicyInfoFilter(*policy.PricingPolicyInfo, filter)
+					if skipFlag {
+						return true
+					}
+				}
+			}
+		}
+
+		fieldStringValue := fmt.Sprintf("%v", fieldValue)
+
+		if value, ok := filter[camelCaseFieldName]; ok {
+			skipFlag := value != nil && *value != fieldStringValue
+			if skipFlag {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func invalidRefelctCheck(value reflect.Value) bool {
+	return value.Kind() == reflect.Array ||
+		value.Kind() == reflect.Slice ||
+		value.Kind() == reflect.Map ||
+		value.Kind() == reflect.Func ||
+		value.Kind() == reflect.Interface ||
+		value.Kind() == reflect.UnsafePointer ||
+		value.Kind() == reflect.Chan
+}
+
+func productInfoFilter(productInfo *irs.ProductInfo, filter map[string]*string) bool {
+	if len(filter) == 0 {
+		return false
+	}
+
+	refelectValue := reflect.ValueOf(*productInfo)
+
+	for i := 0; i < refelectValue.NumField(); i++ {
+		fieldName := refelectValue.Type().Field(i).Name
+
+		if fieldName == "CSPProductInfo" || fieldName == "Description" {
+			continue
+		}
+
+		camelCaseFieldName := toCamelCase(fieldName)
+		fieldValue := refelectValue.Field(i)
+
+		if invalidRefelctCheck(fieldValue) ||
+			fieldValue.Kind() == reflect.Ptr ||
+			fieldValue.Kind() == reflect.Struct {
+			continue
+		}
+
+		fieldStringValue := fmt.Sprintf("%v", fieldValue)
+
+		if value, ok := filter[camelCaseFieldName]; ok {
+			skipFlag := value != nil && *value != fieldStringValue
+
+			if skipFlag {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+func filterListToMap(additionalFilterList []irs.KeyValue) (map[string]*string, bool) { // 키-값 목록을 받아서 필터링 된 맵과 유효성 검사 결과 반환
+	filterMap := make(map[string]*string, 0) // 빈 맵 생성
+
+	if additionalFilterList == nil { // 입력값이 nil이면 빈 맵과 true를 반환합니다.
+		return filterMap, true
+	}
+
+	for _, kv := range additionalFilterList { // 각 키-값 쌍에 대해 다음 작업 수행
+		if _, ok := validFilterKey[kv.Key]; !ok { // 키가 유효한 필터 키 목록에 존재하지 않으면 빈 맵과 false를 반환합니다.
+			return map[string]*string{}, false
+		}
+
+		value := strings.TrimSpace(kv.Value) // 값의 앞뒤 공백을 제거합니다.
+		if value == "" {                     // 값이 빈 문자열이면 다음 키-값 쌍으로 넘어갑니다.
+			continue
+		}
+
+		filterMap[kv.Key] = &value // 맵에 키와 값을 저장합니다.
+	}
+
+	return filterMap, true // 필터링된 맵과 true를 반환합니다.
 }

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/PriceInfoHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/PriceInfoHandler.go
@@ -105,8 +105,8 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 		ServiceCode: aws.String(productFamily),
 		MaxResults:  aws.Int64(1),
 	}
-
-	cblogger.Info("describeServicesinput", describeServicesinput)
+	// for the test
+	// cblogger.Info("describeServicesinput", describeServicesinput)
 
 	services, err := priceInfoHandler.Client.DescribeServices(describeServicesinput)
 	if services == nil {
@@ -186,80 +186,8 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 					Value: aws.String(filter.Value),
 				})
 			}
-			//price
 
-			// if filter.Key == "pricingId" {
-			// 	getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
-			// 		Field: aws.String("priceDimensionsKey"),
-			// 		Type:  aws.String("TERM_MATCH"),
-			// 		Value: aws.String(filter.Value),
-			// 	})
-			// }
-
-			// if filter.Key == "unit" {
-			// 	getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
-			// 		Field: aws.String("unit"),
-			// 		Type:  aws.String("TERM_MATCH"),
-			// 		Value: aws.String(filter.Value),
-			// 	})
-			// }
-			// if filter.Key == "currency" {
-			// 	getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
-			// 		Field: aws.String("currency"),
-			// 		Type:  aws.String("TERM_MATCH"),
-			// 		Value: aws.String(filter.Value),
-			// 	})
-			// }
-			// if filter.Key == "price" {
-			// 	getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
-			// 		Field: aws.String("price"),
-			// 		Type:  aws.String("TERM_MATCH"),
-			// 		Value: aws.String(filter.Value),
-			// 	})
-			// }
-			// if filter.Key == "description" {
-			// 	getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
-			// 		Field: aws.String("description"),
-			// 		Type:  aws.String("TERM_MATCH"),
-			// 		Value: aws.String(filter.Value),
-			// 	})
-			// }
-			// if filter.Key == "leaseContractLength" {
-			// 	getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
-			// 		Field: aws.String("LeaseContractLength"),
-			// 		Type:  aws.String("TERM_MATCH"),
-			// 		Value: aws.String(filter.Value),
-			// 	})
-			// }
-			// if filter.Key == "offeringClass" {
-			// 	getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
-			// 		Field: aws.String("OfferingClass"),
-			// 		Type:  aws.String("TERM_MATCH"),
-			// 		Value: aws.String(filter.Value),
-			// 	})
-			// }
-			// if filter.Key == "purchaseOption" {
-			// 	getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
-			// 		Field: aws.String("preInstalledSw"),
-			// 		Type:  aws.String("TERM_MATCH"),
-			// 		Value: aws.String(filter.Value),
-			// 	})
-			// }
-
-			//: "filter", Value: "{\"Field\":\"instanceType\",\"Type\":\"TERM_MATCH\",\"Value\":\"t2.nano\"}"})
-			// err := json.Unmarshal([]byte(filter.Value), &getProductsinputfilter)
-			// getProductsinputfilters = append(getProductsinputfilters, &getProductsinputfilter)
-
-			// if err != nil {
-			// 	cblogger.Error(err)
-			// 	return "", err
-			// }
-			// // for the test
-			// cblogger.Info("getProductsinputfilter", getProductsinputfilter)
 		}
-
-		// for the test
-		cblogger.Info("[]*pricing.Filter{}", []*pricing.Filter{})
 	}
 	if regionName != "" {
 		getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
@@ -273,18 +201,19 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 		Filters:     getProductsinputfilters,
 		ServiceCode: aws.String(productFamily),
 	}
-	// for the test
-	cblogger.Info("getProductsinput", getProductsinput)
+
 	priceinfos, err := priceInfoHandler.Client.GetProducts(getProductsinput)
 	if err != nil {
 		cblogger.Error(err)
 		return "", err
 	}
+	cblogger.Info("@@@@@@@@@@@@", priceinfos)
 
 	result := &irs.CloudPriceData{}
 	result.Meta.Version = "v0.1"
 	result.Meta.Description = "Multi-Cloud Price Info"
-	cblogger.Info("productInfo", priceinfos)
+	// for the test
+	// cblogger.Info("productInfo", priceinfos)
 	for _, price := range priceinfos.PriceList {
 		jsonString, err := json.MarshalIndent(price["product"].(map[string]interface{})["attributes"], "", "    ")
 		if err != nil {
@@ -307,8 +236,10 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 
 		var priceInfo irs.PriceInfo
 		priceInfo.CSPPriceInfo = price["terms"]
+		cblogger.Info("priceInfo.CSPPriceInfo******************** = ", priceInfo.CSPPriceInfo)
+		cblogger.Info("priceInfo.CSPPriceInfo^^^^^^^^^^^^^^^^^^^^ = ", priceInfo)
 		for termsKey, termsValue := range price["terms"].(map[string]interface{}) {
-			cblogger.Info("termsKey1111111111111111111", termsKey)
+
 			hasTerm := false
 			termVal := ""
 			hasPriceDimension := false
@@ -319,7 +250,6 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 
 				for _, filter := range filterList {
 					// find filter conditions
-
 					if filter.Key == "pricingPolicy" {
 						hasTerm = true
 						termVal = filter.Value
@@ -344,29 +274,17 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 			}
 
 			for _, policyvalue := range termsValue.(map[string]interface{}) {
-				cblogger.Info("policyvalue333333333333", policyvalue)
 				var pricingPolicy irs.PricingPolicies
 				for innerpolicyKey, innerpolicyValue := range policyvalue.(map[string]interface{}) {
 					if innerpolicyKey == "priceDimensions" {
-						cblogger.Info("innerpolicyKey$$$$$$$$$$$$$$$", innerpolicyKey)
-						cblogger.Info("innerpolicyValue~~~~~~~~~~~~~~~~~~~", innerpolicyValue)
 						for priceDimensionsKey, priceDimensionsValue := range innerpolicyValue.(map[string]interface{}) {
-
-							cblogger.Info("priceDimensionsValue@@@@@@@@@@@@@@@@@@@@@@@", priceDimensionsValue)
-
-							cblogger.Info("filterList==============", filterList)
-
 							if filterList != nil {
-								cblogger.Info("hasPriceDimension**************", hasPriceDimension)
-								cblogger.Info("priceDemensionVal%^&%^&%^&%^&%^&", priceDemensionVal)
-								cblogger.Info("priceDimensionsKey||||||||||||||||", priceDimensionsKey)
 								// check filters
 								if hasPriceDimension && priceDemensionVal != priceDimensionsKey {
 
 									continue
 
 								}
-								cblogger.Info("priceDimensionsKey+++++++++++++++++++", priceDimensionsKey)
 								//pricingId의 unit값이 필터 값으로 들어오면 unit 값을 받은 값으로 설정
 								foundSku := false
 								for _, skukey := range priceDimensionsValue.(map[string]interface{}) {
@@ -376,7 +294,6 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 										break
 									}
 								}
-								cblogger.Info("foundSku_+_+_+_+_+_+_+_+_+_+_+_+_+_+", foundSku)
 								if hasunit && !foundSku { // sku를 못 찾았으면 skip.
 									continue
 								}
@@ -396,16 +313,33 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 							}
 							pricingPolicy.Unit = fmt.Sprintf("%s", priceDimensionsValue.(map[string]interface{})["unit"])
 
-							// priceInfo.PricingPolicies = append(priceInfo.PricingPolicies, pricingPolicy)
+							// var cspPriceInfo []string
+
+							// // Convert the []interface{} to []string before appending
+							// for _, item := range price["terms"].([]interface{}) {
+							// 	jsonString, err := json.Marshal(item)
+							// 	if err != nil {
+							// 		cblogger.Error(err)
+							// 		continue
+							// 	}
+							// 	cspPriceInfo = append(cspPriceInfo, string(jsonString))
+							// }
+							priceInfo.PricingPolicies = append(priceInfo.PricingPolicies, pricingPolicy)
 							aPrice, ok := priceMap[productId]
-							cblogger.Info("productId12121212121212121212121212 = ", productId)
+
+							// for the test
+							cblogger.Info("productId111111111111 = ", productId)
+							cblogger.Info("pricingPolicy66666666666 = ", pricingPolicy)
+
 							if ok { // product가 존재하면 policy 추가
 								aPrice.PriceInfo.PricingPolicies = append(aPrice.PriceInfo.PricingPolicies, pricingPolicy)
-
+								// aPrice.PriceInfo.CSPPriceInfo = append(aPrice.PriceInfo.CSPPriceInfo.([]string), cspPriceInfo...)
+								// var priceInfo irs.PriceInfo
+								// priceInfo.CSPPriceInfo = price["terms"]
 								priceMap[productId] = aPrice
-								cblogger.Info("productId12121212121212121212121212 = ", productId)
+
 							} else { // product가 없으면 price 추가
-								cblogger.Info("productId12121212121212121212121212 = ", productId)
+
 								newPriceInfo := irs.PriceInfo{}
 								newPolicies := []irs.PricingPolicies{}
 								newPolicies = append(newPolicies, pricingPolicy)
@@ -413,8 +347,7 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 								newPriceInfo.PricingPolicies = newPolicies
 								// newCSPPriceInfo := []string{}
 								// newCSPPriceInfo = append(newCSPPriceInfo, priceResponseStr)
-								// newPriceInfo.CSPPriceInfo = newCSPPriceInfo
-
+								// newPriceInfo.CSPPriceInfo = newCSPPriceIn
 								newPrice := irs.Price{}
 								newPrice.PriceInfo = newPriceInfo
 								newPrice.ProductInfo = productInfo

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/PriceInfoHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/PriceInfoHandler.go
@@ -97,7 +97,12 @@ func removeSpaces(s string) string {
 // GetPriceInfo는 DescribeServices를 통해 올바른 productFamily 인자만 검사합니다. -> AttributeName에 오류가 있을경우 빈값을 리턴
 
 func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, regionName string, filterList []irs.KeyValue) (string, error) {
-	priceMap := make(map[string]irs.Price)
+	result := &irs.CloudPriceData{}
+	result.Meta.Version = "v0.1"
+	result.Meta.Description = "Multi-Cloud Price Info"
+
+	priceMap := make(map[string]irs.Price) // 전체 price를 id로 구분한 map
+
 	cblogger.Infof("productFamily======", productFamily)
 
 	cblogger.Infof("filter value : %+v", filterList)
@@ -118,360 +123,358 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 		cblogger.Error(err)
 		return "", err
 	}
-	getProductsinputfilters := []*pricing.Filter{}
 
-	if filterList != nil {
-		for _, filter := range filterList {
-			if filter.Key == "instanceType" {
-				getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
-					Field: aws.String("instanceType"),
-					Type:  aws.String("TERM_MATCH"),
-					Value: aws.String(filter.Value),
-				})
-			}
-
-			if filter.Key == "operatingSystem" {
-				getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
-					Field: aws.String("operatingSystem"),
-					Type:  aws.String("TERM_MATCH"),
-					Value: aws.String(filter.Value),
-				})
-			}
-			if filter.Key == "vcpu" {
-				getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
-					Field: aws.String("vcpu"),
-					Type:  aws.String("TERM_MATCH"),
-					Value: aws.String(filter.Value),
-				})
-			}
-			if filter.Key == "productId" {
-				getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
-					Field: aws.String("sku"),
-					Type:  aws.String("TERM_MATCH"),
-					Value: aws.String(filter.Value),
-				})
-			}
-			if filter.Key == "memory" {
-				getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
-					Field: aws.String("memory"),
-					Type:  aws.String("TERM_MATCH"),
-					Value: aws.String(filter.Value),
-				})
-			}
-			if filter.Key == "storage" {
-				getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
-					Field: aws.String("storage"),
-					Type:  aws.String("TERM_MATCH"),
-					Value: aws.String(filter.Value),
-				})
-			}
-			if filter.Key == "gpu" {
-				getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
-					Field: aws.String("gpu"),
-					Type:  aws.String("TERM_MATCH"),
-					Value: aws.String(filter.Value),
-				})
-			}
-			if filter.Key == "gpuMemory" {
-				getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
-					Field: aws.String("gpuMemory"),
-					Type:  aws.String("TERM_MATCH"),
-					Value: aws.String(filter.Value),
-				})
-			}
-			if filter.Key == "preInstalledSw" {
-				getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
-					Field: aws.String("preInstalledSw"),
-					Type:  aws.String("TERM_MATCH"),
-					Value: aws.String(filter.Value),
-				})
-			}
-			// if filter.Key == "leaseContractLength" {
-			// 	getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
-			// 		Field: aws.String("leaseContractLength"),
-			// 		Type:  aws.String("TERM_MATCH"),
-			// 		Value: aws.String(filter.Value),
-			// 	})
-			// }
-
-		}
-	}
+	requestProductsInputFilters, err := setProductsInputRequestFilter(filterList)
 
 	// filter조건에 region 지정.
 	if regionName != "" {
-		getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
+		requestProductsInputFilters = append(requestProductsInputFilters, &pricing.Filter{
 			Field: aws.String("regionCode"),
 			Type:  aws.String("EQUALS"),
 			Value: aws.String(regionName),
 		})
 	} else {
-		getProductsinputfilters = append(getProductsinputfilters, &pricing.Filter{
+		requestProductsInputFilters = append(requestProductsInputFilters, &pricing.Filter{
 			Field: aws.String("regionCode"),
 			Type:  aws.String("EQUALS"),
 			Value: aws.String(priceInfoHandler.Region.Region),
 		})
 	}
 
-	getProductsinput := &pricing.GetProductsInput{
-		Filters:     getProductsinputfilters,
+	getProductsRequest := &pricing.GetProductsInput{
+		Filters:     requestProductsInputFilters,
 		ServiceCode: aws.String(productFamily),
 	}
-	cblogger.Info("get Products request", getProductsinput)
-	priceinfos, err := priceInfoHandler.Client.GetProducts(getProductsinput)
+	cblogger.Info("get Products request", getProductsRequest)
+	priceinfos, err := priceInfoHandler.Client.GetProducts(getProductsRequest)
 	if err != nil {
 		cblogger.Error(err)
 		return "", err
 	}
 	cblogger.Info("get Products response", priceinfos)
 
-	result := &irs.CloudPriceData{}
-	result.Meta.Version = "v0.1"
-	result.Meta.Description = "Multi-Cloud Price Info"
 	// for the test
 	// cblogger.Info("productInfo", priceinfos)
-	for _, price := range priceinfos.PriceList {
-		cblogger.Info("=-=-=-=-=-=-=-=-", price)
-		jsonString, err := json.MarshalIndent(price["product"].(map[string]interface{})["attributes"], "", "    ")
+	for _, awsPrice := range priceinfos.PriceList {
+		productInfo, err := ExtractProductInfo(awsPrice)
 		if err != nil {
 			cblogger.Error(err)
+			continue
 		}
 
-		var productInfo irs.ProductInfo
-		ReplaceEmptyWithNA(&productInfo)
-		err = json.Unmarshal(jsonString, &productInfo)
-		if err != nil {
-			cblogger.Error(err)
-		}
-
-		productId := fmt.Sprintf("%s", price["product"].(map[string]interface{})["sku"])
-		productInfo.ProductId = fmt.Sprintf("%s", price["product"].(map[string]interface{})["sku"])
-		productInfo.RegionName = fmt.Sprintf("%s", price["product"].(map[string]interface{})["attributes"].(map[string]interface{})["regionCode"])
-		productInfo.Description = fmt.Sprintf("productFamily= %s, version= %s", price["product"].(map[string]interface{})["productFamily"], price["version"])
-		productInfo.CSPProductInfo = price["product"]
-		productInfo.ZoneName = "NA" // AWS zone is Not Applicable - 202401
-
-		// var priceInfo irs.PriceInfo
-		// priceInfo.CSPPriceInfo = price["terms"]
-		// cblogger.Info("priceInfo.CSPPriceInfo******************** = ", priceInfo.CSPPriceInfo)
-		// cblogger.Info("priceInfo.CSPPriceInfo^^^^^^^^^^^^^^^^^^^^ = ", priceInfo)
 		// termsKey : OnDemand, Reserved
-		for termsKey, termsValue := range price["terms"].(map[string]interface{}) {
+		for termsKey, termsValue := range awsPrice["terms"].(map[string]interface{}) {
 			cblogger.Info("now termsKey = ", termsKey)
-			hasPricingPolicyVal := false
-			pricingPolicyVal := ""
+			// hasPricingPolicyVal := false
+			// pricingPolicyVal := ""
 
-			hasPriceDimension := false
-			priceDemensionVal := ""
+			// hasPriceDimension := false
+			// priceDemensionVal := ""
 
-			hasunit := false
-			unitVal := ""
+			// hasunit := false
+			// unitVal := ""
 
-			hasLeaseContractLength := false
-			LeaseContractLengthVal := ""
+			// hasLeaseContractLength := false
+			// leaseContractLengthVal := ""
 
-			hasOfferingClass := false
-			OfferingClassVal := ""
+			// hasOfferingClass := false
+			// offeringClassVal := ""
 
-			hasPurchaseOption := false
-			PurchaseOptionVal := ""
+			// hasPurchaseOption := false
+			// purchaseOptionVal := ""
 
-			if filterList != nil {
+			// if filterList != nil {
 
-				for _, filter := range filterList {
-					// find filter conditions
-					if filter.Key == "pricingPolicy" {
-						hasPricingPolicyVal = true
-						pricingPolicyVal = filter.Value
-						continue
-					}
+			// 	for _, filter := range filterList {
+			// 		// find filter conditions
+			// 		if filter.Key == "pricingPolicy" {
+			// 			hasPricingPolicyVal = true
+			// 			pricingPolicyVal = filter.Value
+			// 			continue
+			// 		}
 
-					if filter.Key == "pricingId" {
-						hasPriceDimension = true
-						priceDemensionVal = filter.Value
-						continue
-					}
-					if filter.Key == "unit" {
-						hasunit = true
-						unitVal = filter.Value
-						continue
-					}
-					if filter.Key == "LeaseContractLength" {
-						hasLeaseContractLength = true
-						LeaseContractLengthVal = filter.Value
-						continue
-					}
-					if filter.Key == "OfferingClass" {
-						hasOfferingClass = true
-						OfferingClassVal = filter.Value
-						continue
-					}
-					if filter.Key == "PurchaseOption" {
-						hasPurchaseOption = true
-						PurchaseOptionVal = filter.Value
-						continue
-					}
-				}
-				// check filters
-				if hasPricingPolicyVal && pricingPolicyVal != termsKey {
-					cblogger.Info("filtered by pricingPolicy ", pricingPolicyVal, termsKey)
-					continue
-				}
-			}
+			// 		if filter.Key == "pricingId" {
+			// 			hasPriceDimension = true
+			// 			priceDemensionVal = filter.Value
+			// 			continue
+			// 		}
+			// 		if filter.Key == "unit" {
+			// 			hasunit = true
+			// 			unitVal = filter.Value
+			// 			continue
+			// 		}
+			// 		if filter.Key == "leaseContractLength" {
+			// 			hasLeaseContractLength = true
+			// 			leaseContractLengthVal = filter.Value
+			// 			continue
+			// 		}
+			// 		if filter.Key == "offeringClass" {
+			// 			hasOfferingClass = true
+			// 			offeringClassVal = filter.Value
+			// 			continue
+			// 		}
+			// 		if filter.Key == "purchaseOption" {
+			// 			hasPurchaseOption = true
+			// 			purchaseOptionVal = filter.Value
+			// 			continue
+			// 		}
+			// 	}
+			// 	// check filters
+			// 	if hasPricingPolicyVal && pricingPolicyVal != termsKey {
+			// 		cblogger.Info("filtered by pricingPolicy ", pricingPolicyVal, termsKey)
+			// 		continue
+			// 	}
+			// }
+
+			// 아래 filter조건이 있을 때 ondemand 면 바로 skip
+			//cblogger.Info(termsKey, hasLeaseContractLength, hasOfferingClass, hasPurchaseOption)
+			// if termsKey == "OnDemand" {
+			// 	if hasLeaseContractLength || hasOfferingClass || hasPurchaseOption {
+			// 		cblogger.Info("filtered by Reserved filters ", hasLeaseContractLength, hasOfferingClass, hasPurchaseOption)
+			// 		continue
+			// 	}
+			// }
 
 			for _, policyValue := range termsValue.(map[string]interface{}) {
 				//cblogger.Info("termsValue(((((((", termsValue) // OnDemand 밑 map
-				var pricingPolicy irs.PricingPolicies
-				for innerpolicyKey, innerpolicyValue := range policyValue.(map[string]interface{}) {
-					//cblogger.Info("policyvalue %%%%%%%%%%%%", policyvalue.(map[string]interface{})) // here
-					//cblogger.Info("innerpolicyKey ??????????", innerpolicyKey)                      // termAttribute
-					//cblogger.Info("innerpolicyValue !!!!!!!!!!", innerpolicyValue)                  // map
 
-					if innerpolicyKey == "priceDimensions" {
-						filterResult := false // true면 filter 통과 된 것임.
-						for priceDimensionsKey, priceDimensionsValue := range innerpolicyValue.(map[string]interface{}) {
-							//cblogger.Info("priceDimensionsValue))))))))))))", priceDimensionsValue)
-							if filterList != nil {
-								// check filters
-								if hasPriceDimension && priceDemensionVal != priceDimensionsKey {
-									cblogger.Info("filtered by priceDimensions ", priceDemensionVal, priceDimensionsKey)
-									continue
-								}
-								//pricingId의 unit값이 필터 값으로 들어오면 unit 값을 받은 값으로 설정
-								foundSku := false
-								for _, skukey := range priceDimensionsValue.(map[string]interface{}) {
-									// check filters
-									if hasunit && unitVal == skukey {
-										foundSku = true
-										break
-									}
-								}
-								if hasunit && !foundSku { // sku를 못 찾았으면 skip.
-									cblogger.Info("filtered by Sku ", hasunit, foundSku)
-									continue
-								}
-							}
-
-							pricingPolicy.PricingId = priceDimensionsKey
-							pricingPolicy.PricingPolicy = termsKey
-							pricingPolicy.Description = fmt.Sprintf("%s", priceDimensionsValue.(map[string]interface{})["description"])
-							for key, val := range priceDimensionsValue.(map[string]interface{})["pricePerUnit"].(map[string]interface{}) {
-								pricingPolicy.Currency = key
-								pricingPolicy.Price = fmt.Sprintf("%s", val)
-								// USD is Default.
-								// if NO USD data, accept other currency.
-								if key == "USD" {
-									break
-								}
-								// check filters
-								// if hasTerm && termVal != termsKey {
-								// 	cblogger.Info("filtered by pricingPolicy ", termVal,  termsKey)
-								// 	continue
-								// }
-							}
-							pricingPolicy.Unit = fmt.Sprintf("%s", priceDimensionsValue.(map[string]interface{})["unit"])
-
-							// 기존 로직에서 price add하던 부분
-							// 여기까지 왔으면 filterResult를 완료(true)로 바꿈
-							filterResult = true
-
-						} // end of for
-						if !filterResult {
-							continue // filter걸린게 있으면 filterResult가 false로 유지되었을 것임
-						}
-					}
-
-					// leaseContractLength, offeringClass,purchaseOption 필터 추가
-					// onDemand는 termAttributes 가 비어있을 수 있음.
-					//aPrice, ok := priceMap[productId]
-
-					if innerpolicyKey == "termAttributes" {
-						filterResult := false // true면 filter 통과 된 것임.
-						cblogger.Info("terms ::: ", termsKey)
-						cblogger.Info("termAttribute ::: ", innerpolicyValue)
-						for termAttributeskey, termAttributesValue := range innerpolicyValue.(map[string]interface{}) {
-							cblogger.Info("termAttributeskey!********", termAttributeskey)
-							cblogger.Info("termAttributesValue2////////", termAttributesValue) // TODO : map이 아니라 string값임.
-							if filterList != nil {
-								foundSku := false
-								cblogger.Info("go sku ", termAttributesValue)
-								for _, skukey := range termAttributesValue.(map[string]interface{}) {
-									cblogger.Info("skukey ", skukey)
-									// check filters
-									if hasLeaseContractLength && LeaseContractLengthVal == skukey {
-										foundSku = true
-										break
-									}
-									if hasOfferingClass && OfferingClassVal == skukey {
-										foundSku = true
-										break
-									}
-									if hasPurchaseOption && PurchaseOptionVal == skukey {
-										foundSku = true
-										break
-									}
-									cblogger.Info("end skukey ", skukey)
-
-								}
-								if hasLeaseContractLength && !foundSku { // sku를 못 찾았으면 skip.
-									cblogger.Info("filtered by Sku ", hasLeaseContractLength, foundSku)
-									continue
-								}
-								if hasOfferingClass && !foundSku { // sku를 못 찾았으면 skip.
-									cblogger.Info("filtered by Sku ", hasOfferingClass, foundSku)
-									continue
-								}
-								if hasPurchaseOption && !foundSku { // sku를 못 찾았으면 skip.
-									cblogger.Info("filtered by Sku ", hasPurchaseOption, foundSku)
-									continue
-								}
-							}
-							cblogger.Info("set leaseContractLength ", termAttributesValue.(map[string]interface{})["LeaseContractLength"])
-							// 		spew.Dump("termAttributesValue.(map[string]interface{})[LeaseContractLength]5555555555", termAttributesValue.(map[string]interface{})["LeaseContractLength"])
-							// 		spew.Dump("termAttributesValue6666666666", termAttributesValue)
-							pricingPolicy.PricingPolicyInfo.LeaseContractLength = fmt.Sprintf("%s", termAttributesValue.(map[string]interface{})["LeaseContractLength"])
-							pricingPolicy.PricingPolicyInfo.OfferingClass = fmt.Sprint("%s", innerpolicyValue.(map[string]interface{})["OfferingClass"])
-							pricingPolicy.PricingPolicyInfo.PurchaseOption = fmt.Sprint("%s", innerpolicyValue.(map[string]interface{})["PurchaseOption"])
-
-							filterResult = true // 여기까지 왔으면 filterResult를 완료(true)로 바꿈
-						}
-						cblogger.Info("filterResult2 ", filterResult)
-						if !filterResult {
-							continue // filter걸린게 있으면 filterResult가 false로 유지되었을 것임
-						}
-						cblogger.Info("LeaseContractLength !@!@!@!@!@", pricingPolicy.PricingPolicyInfo.LeaseContractLength)
-					}
-
-					aPrice, ok := priceMap[productId]
-
-					if ok { // product가 존재하면 policy 추가
-						cblogger.Info("product exist ", productId)
-						aPrice.PriceInfo.PricingPolicies = append(aPrice.PriceInfo.PricingPolicies, pricingPolicy)
-						// aPrice.PriceInfo.CSPPriceInfo = append(aPrice.PriceInfo.CSPPriceInfo.([]string), cspPriceInfo...)
-						// var priceInfo irs.PriceInfo
-						// priceInfo.CSPPriceInfo = price["terms"]
-						priceMap[productId] = aPrice
-
-					} else { // product가 없으면 price 추가
-						cblogger.Info("product not exist ", productId)
-
-						newPriceInfo := irs.PriceInfo{}
-						newPolicies := []irs.PricingPolicies{}
-						newPolicies = append(newPolicies, pricingPolicy)
-
-						newPriceInfo.PricingPolicies = newPolicies
-						newPriceInfo.CSPPriceInfo = price["terms"] // 새로운 가격이면 terms아래값을 넣는다.
-
-						// newCSPPriceInfo := []string{}
-						// newCSPPriceInfo = append(newCSPPriceInfo, priceResponseStr)
-						// newPriceInfo.CSPPriceInfo = newCSPPriceIn
-						newPrice := irs.Price{}
-						newPrice.PriceInfo = newPriceInfo
-						newPrice.ProductInfo = productInfo
-
-						priceMap[productId] = newPrice
-					}
-
+				// map이므로 항목을 추출하여 사용하자
+				// OnDemand, Reserved 일 때, 항목이 다름.
+				priceDemensions := make(map[string]interface{})
+				termAttributes := make(map[string]interface{})
+				sku := ""
+				if priceDemensionsVal, ok := policyValue.(map[string]interface{})["priceDimensions"]; ok {
+					cblogger.Info("priceDimensions ", priceDemensionsVal)
+					priceDemensions = priceDemensionsVal.(map[string]interface{})
 				}
+				if termAttributesVal, ok := policyValue.(map[string]interface{})["termAttributes"]; ok {
+					cblogger.Info("termAttributes ", termAttributesVal)
+					termAttributes = termAttributesVal.(map[string]interface{})
+				}
+				if skuVal, ok := policyValue.(map[string]interface{})["sku"]; ok {
+					cblogger.Info("skuVal ", skuVal)
+					skuValString, ok := skuVal.(string)
+					if ok {
+						sku = skuValString
+					}
+				}
+
+				if termsKey == "OnDemand" {
+					for priceDimensionsKey, priceDimensionsValue := range priceDemensions {
+						isFiltered := OnDemandPolicyFilter(priceDimensionsKey, priceDimensionsValue.(map[string]interface{}), termAttributes, sku, filterList)
+						if isFiltered {
+							continue
+						}
+
+						var pricingPolicy irs.PricingPolicies
+						pricingPolicy.PricingId = priceDimensionsKey
+						pricingPolicy.PricingPolicy = termsKey
+						pricingPolicy.Description = fmt.Sprintf("%s", priceDimensionsValue.(map[string]interface{})["description"])
+						for key, val := range priceDimensionsValue.(map[string]interface{})["pricePerUnit"].(map[string]interface{}) {
+							pricingPolicy.Currency = key
+							pricingPolicy.Price = fmt.Sprintf("%s", val)
+							// USD is Default.
+							// if NO USD data, accept other currency.
+							if key == "USD" {
+								break
+							}
+						}
+						pricingPolicy.Unit = fmt.Sprintf("%s", priceDimensionsValue.(map[string]interface{})["unit"])
+
+						// policy 추출하여 추가
+						aPrice, ok := AppendPolicyToPrice(priceMap, productInfo, pricingPolicy, awsPrice)
+						if !ok {
+							priceMap[productInfo.ProductId] = aPrice
+						}
+					}
+
+				} else if termsKey == "Reserved" {
+
+					for priceDimensionsKey, priceDimensionsValue := range priceDemensions {
+						isFiltered := ReservedPolicyFilter(priceDimensionsKey, priceDimensionsValue.(map[string]interface{}), termAttributes, sku, filterList)
+						if isFiltered {
+							continue
+						}
+
+						var pricingPolicy irs.PricingPolicies
+						pricingPolicy.PricingId = priceDimensionsKey
+						pricingPolicy.PricingPolicy = termsKey
+						pricingPolicy.Description = fmt.Sprintf("%s", priceDimensionsValue.(map[string]interface{})["description"])
+						for key, val := range priceDimensionsValue.(map[string]interface{})["pricePerUnit"].(map[string]interface{}) {
+							pricingPolicy.Currency = key
+							pricingPolicy.Price = fmt.Sprintf("%s", val)
+							// USD is Default.
+							// if NO USD data, accept other currency.
+							if key == "USD" {
+								break
+							}
+						}
+						pricingPolicy.Unit = fmt.Sprintf("%s", priceDimensionsValue.(map[string]interface{})["unit"])
+
+						// cblogger.Info("termAttributes>>> ", termAttributes)
+						// cblogger.Info("LeaseContractLength>>> ", termAttributes["LeaseContractLength"])
+
+						pricingPolicyInfo := irs.PricingPolicyInfo{}
+						if leaseContractLength, ok := termAttributes["LeaseContractLength"]; ok {
+							pricingPolicyInfo.LeaseContractLength = leaseContractLength.(string)
+						}
+						if offeringClass, ok := termAttributes["OfferingClass"]; ok {
+							pricingPolicyInfo.OfferingClass = offeringClass.(string)
+						}
+						if purchaseOption, ok := termAttributes["PurchaseOption"]; ok {
+							pricingPolicyInfo.PurchaseOption = purchaseOption.(string)
+						}
+
+						// policy 추출하여 추가
+						aPrice, ok := AppendPolicyToPrice(priceMap, productInfo, pricingPolicy, awsPrice)
+						if !ok {
+							priceMap[productInfo.ProductId] = aPrice
+						}
+					}
+				}
+
+				// var pricingPolicy irs.PricingPolicies
+				// for innerpolicyKey, innerpolicyValue := range policyValue.(map[string]interface{}) {
+				// 	//cblogger.Info("policyvalue %%%%%%%%%%%%", policyvalue.(map[string]interface{})) // here
+				// 	cblogger.Info("innerpolicyKey ?????????? ", innerpolicyKey)     // termAttribute
+				// 	cblogger.Info("innerpolicyValue !!!!!!!!!! ", innerpolicyValue) // map
+
+				// 	// 제품 1개에 대한 비용 부과 단위가 여러개 가능. ex) Hrs, Quantity
+				// 	// 제품에 대한 terAttribute와는 무관, 즉 제품:Dimensions:termAttributes = 1: n : 1
+				// 	if innerpolicyKey == "priceDimensions" {
+				// 		for priceDimensionsKey, priceDimensionsValue := range innerpolicyValue.(map[string]interface{}) {
+				// 			cblogger.Info("priceDimensionsValue))))))))))))", priceDimensionsValue)
+
+				// 			pricingPolicy.PricingId = priceDimensionsKey
+				// 			pricingPolicy.PricingPolicy = termsKey
+				// 			pricingPolicy.Description = fmt.Sprintf("%s", priceDimensionsValue.(map[string]interface{})["description"])
+				// 			for key, val := range priceDimensionsValue.(map[string]interface{})["pricePerUnit"].(map[string]interface{}) {
+				// 				pricingPolicy.Currency = key
+				// 				pricingPolicy.Price = fmt.Sprintf("%s", val)
+				// 				// USD is Default.
+				// 				// if NO USD data, accept other currency.
+				// 				if key == "USD" {
+				// 					break
+				// 				}
+
+				// 			}
+				// 			pricingPolicy.Unit = fmt.Sprintf("%s", priceDimensionsValue.(map[string]interface{})["unit"])
+
+				// 		} // end of for
+				// 	} // end of priceDimensions
+
+				// 	if innerpolicyKey == "termAttributes" {
+				// 		cblogger.Info("terms ::: ", termsKey)
+				// 		cblogger.Info("termAttribute ::: ", innerpolicyValue)
+				// 		// innerpolicyMap := innerpolicyValue.(map[string]interface{})
+				// 		// if value, ok := innerpolicyMap["LeaseContractLength"]; ok {
+				// 		// 	leaseContractLength, ok := value.(string)
+				// 		// 	// 변수에 값이 성공적으로 담겼을 경우
+				// 		// 	if ok {
+				// 		// 		if hasLeaseContractLength && leaseContractLengthVal != value {
+				// 		// 			continue
+				// 		// 		}
+				// 		// 		cblogger.Info("LeaseContractLength 변수:", leaseContractLength)
+				// 		// 		//pricingPolicy.PricingPolicyInfo.LeaseContractLength = leaseContractLength
+				// 		// 	} else { // 타입 단언에 실패한 경우
+				// 		// 		cblogger.Info("LeaseContractLength의 데이터 타입을 가져올 수 없습니다.")
+				// 		// 		continue
+				// 		// 	}
+				// 		// } else {
+				// 		// 	// "LeaseContractLength" 키가 존재하지 않는 경우
+				// 		// 	cblogger.Info("LeaseContractLength 키가 존재하지 않습니다. ", innerpolicyValue)
+				// 		// 	continue
+				// 		// }
+
+				// 		// cblogger.Info("offeringClassVal = offeringClassVal ", offeringClassVal)
+				// 		// cblogger.Info("purchaseOptionVal = offeringClassVal ", purchaseOptionVal)
+				// 		// map[LeaseContractLength:1yr OfferingClass:convertible PurchaseOption:No Upfront]
+
+				// 		// pricingPolicy.PricingPolicyInfo.LeaseContractLength = fmt.Sprintf("%s", termAttributesValue.(map[string]interface{})["LeaseContractLength"])
+				// 		// pricingPolicy.PricingPolicyInfo.OfferingClass = fmt.Sprint("%s", innerpolicyValue.(map[string]interface{})["OfferingClass"])
+				// 		// pricingPolicy.PricingPolicyInfo.PurchaseOption = fmt.Sprint("%s", innerpolicyValue.(map[string]interface{})["PurchaseOption"])
+
+				// 		// for termAttributeskey, termAttributesValue := range innerpolicyValue.(map[string]interface{}) {
+				// 		// 	cblogger.Info("termAttributeskey!********", termAttributeskey)
+				// 		// 	cblogger.Info("termAttributesValue2////////", termAttributesValue) // TODO : map이 아니라 string값임.
+
+				// 		// if hasLeaseContractLength && leaseContractLengthVal !=
+				// 		// foundSku := false
+				// 		// cblogger.Info("go sku ", termAttributesValue)
+				// 		// for _, skukey := range termAttributesValue.(map[string]interface{}) {
+				// 		// 	cblogger.Info("skukey ", skukey)
+				// 		// 	// check filters
+				// 		// 	if hasLeaseContractLength && LeaseContractLengthVal == skukey {
+				// 		// 		foundSku = true
+				// 		// 		break
+				// 		// 	}
+				// 		// 	if hasOfferingClass && OfferingClassVal == skukey {
+				// 		// 		foundSku = true
+				// 		// 		break
+				// 		// 	}
+				// 		// 	if hasPurchaseOption && PurchaseOptionVal == skukey {
+				// 		// 		foundSku = true
+				// 		// 		break
+				// 		// 	}
+				// 		// 	cblogger.Info("end skukey ", skukey)
+
+				// 		// }
+				// 		// if hasLeaseContractLength && !foundSku { // sku를 못 찾았으면 skip.
+				// 		// 	cblogger.Info("filtered by Sku ", hasLeaseContractLength, foundSku)
+				// 		// 	continue
+				// 		// }
+				// 		// if hasOfferingClass && !foundSku { // sku를 못 찾았으면 skip.
+				// 		// 	cblogger.Info("filtered by Sku ", hasOfferingClass, foundSku)
+				// 		// 	continue
+				// 		// }
+				// 		// if hasPurchaseOption && !foundSku { // sku를 못 찾았으면 skip.
+				// 		// 	cblogger.Info("filtered by Sku ", hasPurchaseOption, foundSku)
+				// 		// 	continue
+				// 		// }
+
+				// 		// cblogger.Info("set leaseContractLength ", termAttributesValue.(map[string]interface{})["LeaseContractLength"])
+				// 		// 		spew.Dump("termAttributesValue.(map[string]interface{})[LeaseContractLength]5555555555", termAttributesValue.(map[string]interface{})["LeaseContractLength"])
+				// 		// 		spew.Dump("termAttributesValue6666666666", termAttributesValue)
+				// 		// pricingPolicy.PricingPolicyInfo.LeaseContractLength = fmt.Sprintf("%s", termAttributesValue.(map[string]interface{})["LeaseContractLength"])
+				// 		// pricingPolicy.PricingPolicyInfo.OfferingClass = fmt.Sprint("%s", innerpolicyValue.(map[string]interface{})["OfferingClass"])
+				// 		// pricingPolicy.PricingPolicyInfo.PurchaseOption = fmt.Sprint("%s", innerpolicyValue.(map[string]interface{})["PurchaseOption"])
+
+				// 		// }
+
+				// 		//cblogger.Info("LeaseContractLength !@!@!@!@!@", pricingPolicy.PricingPolicyInfo.LeaseContractLength)
+				// 	}
+
+				// } // end of innerpolicyKey
+
+				// aPrice, ok := priceMap[productId]
+
+				// if ok { // product가 존재하면 policy 추가
+				// 	cblogger.Info("product exist ", productId)
+				// 	aPrice.PriceInfo.PricingPolicies = append(aPrice.PriceInfo.PricingPolicies, pricingPolicy)
+				// 	// aPrice.PriceInfo.CSPPriceInfo = append(aPrice.PriceInfo.CSPPriceInfo.([]string), cspPriceInfo...)
+				// 	// var priceInfo irs.PriceInfo
+				// 	// priceInfo.CSPPriceInfo = price["terms"]
+				// 	priceMap[productId] = aPrice
+
+				// } else { // product가 없으면 price 추가
+				// 	cblogger.Info("product not exist ", productId)
+
+				// 	newPriceInfo := irs.PriceInfo{}
+				// 	newPolicies := []irs.PricingPolicies{}
+				// 	newPolicies = append(newPolicies, pricingPolicy)
+
+				// 	newPriceInfo.PricingPolicies = newPolicies
+				// 	newPriceInfo.CSPPriceInfo = price["terms"] // 새로운 가격이면 terms아래값을 넣는다.
+
+				// 	// newCSPPriceInfo := []string{}
+				// 	// newCSPPriceInfo = append(newCSPPriceInfo, priceResponseStr)
+				// 	// newPriceInfo.CSPPriceInfo = newCSPPriceIn
+				// 	newPrice := irs.Price{}
+				// 	newPrice.PriceInfo = newPriceInfo
+				// 	newPrice.ProductInfo = productInfo
+
+				// 	priceMap[productId] = newPrice
+				// }
 			}
 		}
 
@@ -500,4 +503,358 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 	}
 	cblogger.Info("return ", string(resultString))
 	return string(resultString), nil
+}
+
+// 가져온 결과에서 product 추출
+func ExtractProductInfo(jsonValue aws.JSONValue) (irs.ProductInfo, error) {
+	var productInfo irs.ProductInfo
+
+	cblogger.Info("=-=-=-=-=-=-=-=-", jsonValue)
+	jsonString, err := json.MarshalIndent(jsonValue["product"].(map[string]interface{})["attributes"], "", "    ")
+	if err != nil {
+		cblogger.Error(err)
+		return productInfo, err
+	}
+
+	ReplaceEmptyWithNA(&productInfo)
+	err = json.Unmarshal(jsonString, &productInfo)
+	if err != nil {
+		cblogger.Error(err)
+		return productInfo, err
+	}
+
+	productId := fmt.Sprintf("%s", jsonValue["product"].(map[string]interface{})["sku"])
+	productInfo.ProductId = productId
+	productInfo.RegionName = fmt.Sprintf("%s", jsonValue["product"].(map[string]interface{})["attributes"].(map[string]interface{})["regionCode"])
+	productInfo.Description = fmt.Sprintf("productFamily= %s, version= %s", jsonValue["product"].(map[string]interface{})["productFamily"], jsonValue["version"])
+	productInfo.CSPProductInfo = jsonValue["product"]
+	productInfo.ZoneName = "NA" // AWS zone is Not Applicable - 202401
+
+	return productInfo, nil
+
+}
+
+// price에 해당 product가 있으면 append, 없으면 추가
+func AppendPolicyToPrice(priceMap map[string]irs.Price, productInfo irs.ProductInfo, pricingPolicy irs.PricingPolicies, jsonValue aws.JSONValue) (irs.Price, bool) {
+	productId := productInfo.ProductId
+	aPrice, ok := priceMap[productId]
+
+	if ok { // product가 존재하면 policy 추가
+		cblogger.Info("product exist ", productId)
+		aPrice.PriceInfo.PricingPolicies = append(aPrice.PriceInfo.PricingPolicies, pricingPolicy)
+		priceMap[productId] = aPrice
+		return aPrice, true
+	} else { // product가 없으면 price 추가
+		cblogger.Info("product not exist ", productId)
+
+		newPriceInfo := irs.PriceInfo{}
+		newPolicies := []irs.PricingPolicies{}
+		newPolicies = append(newPolicies, pricingPolicy)
+
+		newPriceInfo.PricingPolicies = newPolicies
+		newPriceInfo.CSPPriceInfo = jsonValue // 새로운 가격이면 terms아래값을 넣는다.
+
+		newPrice := irs.Price{}
+		newPrice.PriceInfo = newPriceInfo
+		newPrice.ProductInfo = productInfo
+
+		priceMap[productId] = newPrice
+
+		return newPrice, true
+	}
+}
+
+// 요청시 필요한 filter Set.
+func setProductsInputRequestFilter(filterList []irs.KeyValue) ([]*pricing.Filter, error) {
+	requestFilters := []*pricing.Filter{}
+
+	if filterList != nil {
+		for _, filter := range filterList {
+			if filter.Key == "instanceType" {
+				requestFilters = append(requestFilters, &pricing.Filter{
+					Field: aws.String("instanceType"),
+					Type:  aws.String("TERM_MATCH"),
+					Value: aws.String(filter.Value),
+				})
+			}
+
+			if filter.Key == "operatingSystem" {
+				requestFilters = append(requestFilters, &pricing.Filter{
+					Field: aws.String("operatingSystem"),
+					Type:  aws.String("TERM_MATCH"),
+					Value: aws.String(filter.Value),
+				})
+			}
+			if filter.Key == "vcpu" {
+				requestFilters = append(requestFilters, &pricing.Filter{
+					Field: aws.String("vcpu"),
+					Type:  aws.String("TERM_MATCH"),
+					Value: aws.String(filter.Value),
+				})
+			}
+			if filter.Key == "productId" {
+				requestFilters = append(requestFilters, &pricing.Filter{
+					Field: aws.String("sku"),
+					Type:  aws.String("TERM_MATCH"),
+					Value: aws.String(filter.Value),
+				})
+			}
+			if filter.Key == "memory" {
+				requestFilters = append(requestFilters, &pricing.Filter{
+					Field: aws.String("memory"),
+					Type:  aws.String("TERM_MATCH"),
+					Value: aws.String(filter.Value),
+				})
+			}
+			if filter.Key == "storage" {
+				requestFilters = append(requestFilters, &pricing.Filter{
+					Field: aws.String("storage"),
+					Type:  aws.String("TERM_MATCH"),
+					Value: aws.String(filter.Value),
+				})
+			}
+			if filter.Key == "gpu" {
+				requestFilters = append(requestFilters, &pricing.Filter{
+					Field: aws.String("gpu"),
+					Type:  aws.String("TERM_MATCH"),
+					Value: aws.String(filter.Value),
+				})
+			}
+			if filter.Key == "gpuMemory" {
+				requestFilters = append(requestFilters, &pricing.Filter{
+					Field: aws.String("gpuMemory"),
+					Type:  aws.String("TERM_MATCH"),
+					Value: aws.String(filter.Value),
+				})
+			}
+			if filter.Key == "preInstalledSw" {
+				requestFilters = append(requestFilters, &pricing.Filter{
+					Field: aws.String("preInstalledSw"),
+					Type:  aws.String("TERM_MATCH"),
+					Value: aws.String(filter.Value),
+				})
+			}
+			// if filter.Key == "leaseContractLength" {
+			// 	requestFilters = append(requestFilters, &pricing.Filter{
+			// 		Field: aws.String("leaseContractLength"),
+			// 		Type:  aws.String("TERM_MATCH"),
+			// 		Value: aws.String(filter.Value),
+			// 	})
+			// }
+
+		} //end of for
+	} // end of if
+	return requestFilters, nil
+}
+
+// 결과에서 filter. filter에 걸리면 true, 안걸리면 false
+func OnDemandPolicyFilter(priceDimensionsKey string, priceDimensions map[string]interface{}, termAttributes map[string]interface{}, sku string, filterList []irs.KeyValue) bool {
+	isFiltered := false
+
+	hasPricingPolicy := false
+	pricingPolicyVal := ""
+
+	hasPriceDimension := false
+	priceDemensionVal := ""
+
+	hasUnit := false
+	unitVal := ""
+
+	// reserved only options
+	hasLeaseContractLength := false
+	//leaseContractLengthVal := ""
+	hasOfferingClass := false
+	//offeringClassVal := ""
+	hasPurchaseOption := false
+	//purchaseOptionVal := ""
+
+	if filterList != nil {
+
+		for _, filter := range filterList {
+			// find filter conditions
+			if filter.Key == "pricingPolicy" {
+				hasPricingPolicy = true
+				pricingPolicyVal = filter.Value
+				continue
+			}
+
+			if filter.Key == "pricingId" {
+				hasPriceDimension = true
+				priceDemensionVal = filter.Value
+				continue
+			}
+			if filter.Key == "unit" {
+				hasUnit = true
+				unitVal = filter.Value
+				continue
+			}
+			if filter.Key == "leaseContractLength" {
+				hasLeaseContractLength = true
+				// leaseContractLengthVal = filter.Value
+				break
+			}
+			if filter.Key == "offeringClass" {
+				hasOfferingClass = true
+				// offeringClassVal = filter.Value
+				break
+			}
+			if filter.Key == "purchaseOption" {
+				hasPurchaseOption = true
+				// purchaseOptionVal = filter.Value
+				break
+			}
+		}
+		// check filters
+
+	}
+
+	if hasLeaseContractLength || hasOfferingClass || hasPurchaseOption { // reserved 전용 filter 임.
+		cblogger.Info("filtered by reserved options ", hasLeaseContractLength, hasOfferingClass, hasPurchaseOption)
+		return true
+	}
+
+	if hasPricingPolicy { //
+		//if pricingPolicyVal != priceDimensions["pricingPolicy"] {
+		if pricingPolicyVal != "OnDemand" {
+			cblogger.Info("filtered by pricingPolicy ", pricingPolicyVal, priceDimensions["pricingPolicy"])
+			return true
+		}
+	}
+	if hasUnit {
+		for key, val := range priceDimensions["pricePerUnit"].(map[string]interface{}) {
+			// USD is Default.
+			// if NO USD data, accept other currency.
+			if key == "USD" {
+				if unitVal != val {
+					cblogger.Info("filtered by price per unit ", unitVal, priceDimensions["pricePerUnit"])
+					return true
+				}
+				break
+			}
+		}
+	}
+
+	if hasPriceDimension {
+		if priceDemensionVal != priceDimensionsKey { // priceId
+			cblogger.Info("filtered by priceDimension ", priceDemensionVal, priceDimensionsKey)
+			return true
+		}
+	}
+
+	cblogger.Info("1.pricingPolicyVal ", pricingPolicyVal, hasPricingPolicy, priceDimensions["pricingPolicy"])
+	cblogger.Info("2.priceDemensionVal ", priceDemensionVal, hasPriceDimension, priceDimensionsKey)
+	cblogger.Info("3.unitVal ", unitVal, hasUnit)
+
+	return isFiltered
+}
+
+// filter에 걸리면 true
+func ReservedPolicyFilter(priceDimensionsKey string, priceDimensionsValue map[string]interface{}, termAttributes map[string]interface{}, sku string, filterList []irs.KeyValue) bool {
+	isFiltered := false
+
+	hasPricingPolicy := false
+	pricingPolicyVal := ""
+
+	hasPriceDimension := false
+	priceDemensionVal := ""
+
+	hasUnit := false
+	unitVal := ""
+
+	hasLeaseContractLength := false
+	leaseContractLengthVal := ""
+
+	hasOfferingClass := false
+	offeringClassVal := ""
+
+	hasPurchaseOption := false
+	purchaseOptionVal := ""
+
+	if filterList != nil {
+
+		for _, filter := range filterList {
+			// find filter conditions
+			if filter.Key == "pricingPolicy" {
+				hasPricingPolicy = true
+				pricingPolicyVal = filter.Value
+				continue
+			}
+
+			if filter.Key == "pricingId" {
+				hasPriceDimension = true
+				priceDemensionVal = filter.Value
+				continue
+			}
+			if filter.Key == "unit" {
+				hasUnit = true
+				unitVal = filter.Value
+				continue
+			}
+			if filter.Key == "leaseContractLength" {
+				hasLeaseContractLength = true
+				leaseContractLengthVal = filter.Value
+				continue
+			}
+			if filter.Key == "offeringClass" {
+				hasOfferingClass = true
+				offeringClassVal = filter.Value
+				continue
+			}
+			if filter.Key == "purchaseOption" {
+				hasPurchaseOption = true
+				purchaseOptionVal = filter.Value
+				continue
+			}
+		}
+	}
+
+	if hasPriceDimension {
+		if priceDemensionVal != priceDimensionsKey { // priceId
+			cblogger.Info("filtered by priceDimension ", priceDemensionVal, priceDimensionsKey)
+			return true
+		}
+	}
+
+	if hasPricingPolicy {
+		if pricingPolicyVal != "Reserved" {
+			cblogger.Info("filtered by pricingPolicy reserved only ", pricingPolicyVal)
+			return true
+		}
+	}
+	if hasUnit {
+		for key, val := range priceDimensionsValue["pricePerUnit"].(map[string]interface{}) {
+			// USD is Default.
+			// if NO USD data, accept other currency.
+			if key == "USD" {
+				if unitVal != val {
+					return true
+				}
+				break
+			}
+
+		}
+	}
+
+	if hasLeaseContractLength {
+		if leaseContractLengthVal != termAttributes["LeaseContractLength"] { // 계약 기간 : 1yr, 3yr ...
+			cblogger.Info("filtered by LeaseContractLength ", priceDemensionVal, termAttributes["LeaseContractLength"])
+			return true
+		}
+	}
+
+	if hasOfferingClass {
+		if offeringClassVal != termAttributes["OfferingClass"] { // 계약 종류 : standard, convertible ...
+			cblogger.Info("filtered by OfferingClass ", offeringClassVal, termAttributes["OfferingClass"])
+			return true
+		}
+	}
+
+	cblogger.Info("11.pricingPolicyVal ", pricingPolicyVal, hasPricingPolicy)
+	cblogger.Info("22.priceDemensionVal ", priceDemensionVal, hasPriceDimension)
+	cblogger.Info("33.unitVal ", unitVal, hasUnit)
+	cblogger.Info("44.leaseContractLengthVal ", leaseContractLengthVal, hasLeaseContractLength)
+	cblogger.Info("55.offeringClassVal ", offeringClassVal, hasOfferingClass)
+	cblogger.Info("66.purchaseOptionVal ", purchaseOptionVal, hasPurchaseOption)
+
+	return isFiltered
 }

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/PriceInfoHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/PriceInfoHandler.go
@@ -207,13 +207,12 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 		cblogger.Error(err)
 		return "", err
 	}
-	cblogger.Info("@@@@@@@@@@@@", priceinfos)
 
 	result := &irs.CloudPriceData{}
 	result.Meta.Version = "v0.1"
 	result.Meta.Description = "Multi-Cloud Price Info"
 	// for the test
-	// cblogger.Info("productInfo", priceinfos)
+	//  "productInfo", priceinfos)
 	for _, price := range priceinfos.PriceList {
 		jsonString, err := json.MarshalIndent(price["product"].(map[string]interface{})["attributes"], "", "    ")
 		if err != nil {
@@ -236,8 +235,6 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 
 		var priceInfo irs.PriceInfo
 		priceInfo.CSPPriceInfo = price["terms"]
-		cblogger.Info("priceInfo.CSPPriceInfo******************** = ", priceInfo.CSPPriceInfo)
-		cblogger.Info("priceInfo.CSPPriceInfo^^^^^^^^^^^^^^^^^^^^ = ", priceInfo)
 		for termsKey, termsValue := range price["terms"].(map[string]interface{}) {
 
 			hasTerm := false
@@ -313,27 +310,24 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 							}
 							pricingPolicy.Unit = fmt.Sprintf("%s", priceDimensionsValue.(map[string]interface{})["unit"])
 
-							// var cspPriceInfo []string
+							var cspPriceInfo []string
 
-							// // Convert the []interface{} to []string before appending
-							// for _, item := range price["terms"].([]interface{}) {
-							// 	jsonString, err := json.Marshal(item)
-							// 	if err != nil {
-							// 		cblogger.Error(err)
-							// 		continue
-							// 	}
-							// 	cspPriceInfo = append(cspPriceInfo, string(jsonString))
-							// }
+							// Convert the []interface{} to []string before appending
+							for _, item := range price["terms"].(map[string]interface{}) {
+								jsonString, err := json.Marshal(item)
+								if err != nil {
+									cblogger.Error(err)
+									continue
+								}
+								cspPriceInfo = append(cspPriceInfo, string(jsonString))
+							}
+
 							priceInfo.PricingPolicies = append(priceInfo.PricingPolicies, pricingPolicy)
 							aPrice, ok := priceMap[productId]
 
-							// for the test
-							cblogger.Info("productId111111111111 = ", productId)
-							cblogger.Info("pricingPolicy66666666666 = ", pricingPolicy)
-
 							if ok { // product가 존재하면 policy 추가
 								aPrice.PriceInfo.PricingPolicies = append(aPrice.PriceInfo.PricingPolicies, pricingPolicy)
-								// aPrice.PriceInfo.CSPPriceInfo = append(aPrice.PriceInfo.CSPPriceInfo.([]string), cspPriceInfo...)
+								aPrice.PriceInfo.CSPPriceInfo = append(aPrice.PriceInfo.CSPPriceInfo.([][]string), cspPriceInfo)
 								// var priceInfo irs.PriceInfo
 								// priceInfo.CSPPriceInfo = price["terms"]
 								priceMap[productId] = aPrice
@@ -345,12 +339,14 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 								newPolicies = append(newPolicies, pricingPolicy)
 
 								newPriceInfo.PricingPolicies = newPolicies
-								// newCSPPriceInfo := []string{}
-								// newCSPPriceInfo = append(newCSPPriceInfo, priceResponseStr)
-								// newPriceInfo.CSPPriceInfo = newCSPPriceIn
+
+								newCSPPriceInfo := [][]string{}
+								newCSPPriceInfo = append(newCSPPriceInfo, cspPriceInfo)
+
 								newPrice := irs.Price{}
 								newPrice.PriceInfo = newPriceInfo
 								newPrice.ProductInfo = productInfo
+								newPrice.PriceInfo.CSPPriceInfo = newCSPPriceInfo
 
 								priceMap[productId] = newPrice
 							}

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/PriceInfoHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/PriceInfoHandler.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
 	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
@@ -23,73 +22,9 @@ type AwsPriceInfoHandler struct {
 // getPricingClient에 Client *pricing.Pricing 정의
 func (priceInfoHandler *AwsPriceInfoHandler) ListProductFamily(regionName string) ([]string, error) {
 	var result []string
+
 	result = append(result, "AmazonEC2")
-	// input := &pricing.GetAttributeValuesInput{
-	// 	AttributeName: aws.String("productfamily"),
-	// 	MaxResults:    aws.Int64(32), // 2024.01 기준 32개
-	// 	ServiceCode:   aws.String("AmazonEC2"),
-	// }
-
-	// cblogger.Info("input 1321312434242341312312", input)
-	// for {
-	// 	attributeValues, err := priceInfoHandler.Client.GetAttributeValues(input)
-	// 	if err != nil {
-	// 		if aerr, ok := err.(awserr.Error); ok {
-	// 			switch aerr.Code() {
-	// 			case pricing.ErrCodeInternalErrorException:
-	// 				cblogger.Error(pricing.ErrCodeInternalErrorException, aerr.Error())
-	// 			case pricing.ErrCodeInvalidParameterException:
-	// 				cblogger.Error(pricing.ErrCodeInvalidParameterException, aerr.Error())
-	// 			case pricing.ErrCodeNotFoundException:
-	// 				cblogger.Error(pricing.ErrCodeNotFoundException, aerr.Error())
-	// 			case pricing.ErrCodeInvalidNextTokenException:
-	// 				cblogger.Error(pricing.ErrCodeInvalidNextTokenException, aerr.Error())
-	// 			case pricing.ErrCodeExpiredNextTokenException:
-	// 				cblogger.Error(pricing.ErrCodeExpiredNextTokenException, aerr.Error())
-	// 			default:
-	// 				cblogger.Error(aerr.Error())
-	// 			}
-	// 		} else {
-	// 			// Prnit the error, cast err to awserr.Error to get the Code and
-	// 			// Message from an error.
-	// 			cblogger.Error(err.Error())
-	// 		}
-	// 	}
-
-	// 	for _, attributeValue := range attributeValues.AttributeValues {
-
-	// 		//result = append(result, *attributeValue.Value)
-	// 		result = append(result, *attributeValue.Value)
-	// 	}
-
-	// 	for i := range attributeValues.AttributeValues {
-	// 		result[i] = removeSpaces(result[i])
-	// 	}
-
-	// 	for _, attributeValue := range attributeValues.AttributeValues {
-	// 		attributeValue.Value = aws.String(strings.ReplaceAll(*attributeValue.Value, " ", ""))
-	// 	}
-
-	// 	// 결과 출력
-	// 	cblogger.Info("rkskekfkekfkekfkekf", attributeValues)
-	// 	fmt.Printf("%+v\n", attributeValues)
-
-	// 	cblogger.Info("attributeValue0000000000000000000000000000", attributeValues.AttributeValues)
-
-	// 	cblogger.Info("attributeValue===============================", result)
-	// 	if attributeValues.NextToken != nil {
-	// 		input = &pricing.GetAttributeValuesInput{
-	// 			NextToken: attributeValues.NextToken,
-	// 		}
-	// 	} else {
-	// 		break
-	// 	}
-	// }
-
 	return result, nil
-}
-func removeSpaces(s string) string {
-	return strings.ReplaceAll(s, " ", "")
 }
 
 // AWS에서는 ListProductFamily를 통해 ProductFamily와 AttributeName을 수집하고,
@@ -103,17 +38,16 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 
 	priceMap := make(map[string]irs.Price) // 전체 price를 id로 구분한 map
 
-	cblogger.Infof("productFamily======", productFamily)
+	cblogger.Info("productFamily======", productFamily)
 
-	cblogger.Infof("filter value : %+v", filterList)
+	cblogger.Info("filter value : ", filterList)
 	describeServicesinput := &pricing.DescribeServicesInput{
 		ServiceCode: aws.String(productFamily),
 		MaxResults:  aws.Int64(1),
 	}
-	// for the test
-	// cblogger.Info("describeServicesinput", describeServicesinput)
 
 	services, err := priceInfoHandler.Client.DescribeServices(describeServicesinput)
+
 	if services == nil {
 		cblogger.Error("No services in given productFamily. CHECK productFamily!")
 		return "", err
@@ -153,8 +87,6 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 	}
 	cblogger.Info("get Products response", priceinfos)
 
-	// for the test
-	// cblogger.Info("productInfo", priceinfos)
 	for _, awsPrice := range priceinfos.PriceList {
 		productInfo, err := ExtractProductInfo(awsPrice)
 		if err != nil {
@@ -164,95 +96,18 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 
 		// termsKey : OnDemand, Reserved
 		for termsKey, termsValue := range awsPrice["terms"].(map[string]interface{}) {
-			cblogger.Info("now termsKey = ", termsKey)
-			// hasPricingPolicyVal := false
-			// pricingPolicyVal := ""
-
-			// hasPriceDimension := false
-			// priceDemensionVal := ""
-
-			// hasunit := false
-			// unitVal := ""
-
-			// hasLeaseContractLength := false
-			// leaseContractLengthVal := ""
-
-			// hasOfferingClass := false
-			// offeringClassVal := ""
-
-			// hasPurchaseOption := false
-			// purchaseOptionVal := ""
-
-			// if filterList != nil {
-
-			// 	for _, filter := range filterList {
-			// 		// find filter conditions
-			// 		if filter.Key == "pricingPolicy" {
-			// 			hasPricingPolicyVal = true
-			// 			pricingPolicyVal = filter.Value
-			// 			continue
-			// 		}
-
-			// 		if filter.Key == "pricingId" {
-			// 			hasPriceDimension = true
-			// 			priceDemensionVal = filter.Value
-			// 			continue
-			// 		}
-			// 		if filter.Key == "unit" {
-			// 			hasunit = true
-			// 			unitVal = filter.Value
-			// 			continue
-			// 		}
-			// 		if filter.Key == "leaseContractLength" {
-			// 			hasLeaseContractLength = true
-			// 			leaseContractLengthVal = filter.Value
-			// 			continue
-			// 		}
-			// 		if filter.Key == "offeringClass" {
-			// 			hasOfferingClass = true
-			// 			offeringClassVal = filter.Value
-			// 			continue
-			// 		}
-			// 		if filter.Key == "purchaseOption" {
-			// 			hasPurchaseOption = true
-			// 			purchaseOptionVal = filter.Value
-			// 			continue
-			// 		}
-			// 	}
-			// 	// check filters
-			// 	if hasPricingPolicyVal && pricingPolicyVal != termsKey {
-			// 		cblogger.Info("filtered by pricingPolicy ", pricingPolicyVal, termsKey)
-			// 		continue
-			// 	}
-			// }
-
-			// 아래 filter조건이 있을 때 ondemand 면 바로 skip
-			//cblogger.Info(termsKey, hasLeaseContractLength, hasOfferingClass, hasPurchaseOption)
-			// if termsKey == "OnDemand" {
-			// 	if hasLeaseContractLength || hasOfferingClass || hasPurchaseOption {
-			// 		cblogger.Info("filtered by Reserved filters ", hasLeaseContractLength, hasOfferingClass, hasPurchaseOption)
-			// 		continue
-			// 	}
-			// }
-
 			for _, policyValue := range termsValue.(map[string]interface{}) {
-				//cblogger.Info("termsValue(((((((", termsValue) // OnDemand 밑 map
-
-				// map이므로 항목을 추출하여 사용하자
 				// OnDemand, Reserved 일 때, 항목이 다름.
 				priceDemensions := make(map[string]interface{})
 				termAttributes := make(map[string]interface{})
 				sku := ""
 				if priceDemensionsVal, ok := policyValue.(map[string]interface{})["priceDimensions"]; ok {
-					cblogger.Info("priceDimensions ", priceDemensionsVal)
 					priceDemensions = priceDemensionsVal.(map[string]interface{})
 				}
 				if termAttributesVal, ok := policyValue.(map[string]interface{})["termAttributes"]; ok {
-					cblogger.Info("termAttributes ", termAttributesVal)
 					termAttributes = termAttributesVal.(map[string]interface{})
 				}
 				if skuVal, ok := policyValue.(map[string]interface{})["sku"]; ok {
-					cblogger.Info("skuVal ", skuVal)
 					skuValString, ok := skuVal.(string)
 					if ok {
 						sku = skuValString
@@ -311,9 +166,6 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 						}
 						pricingPolicy.Unit = fmt.Sprintf("%s", priceDimensionsValue.(map[string]interface{})["unit"])
 
-						// cblogger.Info("termAttributes>>> ", termAttributes)
-						// cblogger.Info("LeaseContractLength>>> ", termAttributes["LeaseContractLength"])
-
 						pricingPolicyInfo := irs.PricingPolicyInfo{}
 						if leaseContractLength, ok := termAttributes["LeaseContractLength"]; ok {
 							pricingPolicyInfo.LeaseContractLength = leaseContractLength.(string)
@@ -332,156 +184,8 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 						}
 					}
 				}
-
-				// var pricingPolicy irs.PricingPolicies
-				// for innerpolicyKey, innerpolicyValue := range policyValue.(map[string]interface{}) {
-				// 	//cblogger.Info("policyvalue %%%%%%%%%%%%", policyvalue.(map[string]interface{})) // here
-				// 	cblogger.Info("innerpolicyKey ?????????? ", innerpolicyKey)     // termAttribute
-				// 	cblogger.Info("innerpolicyValue !!!!!!!!!! ", innerpolicyValue) // map
-
-				// 	// 제품 1개에 대한 비용 부과 단위가 여러개 가능. ex) Hrs, Quantity
-				// 	// 제품에 대한 terAttribute와는 무관, 즉 제품:Dimensions:termAttributes = 1: n : 1
-				// 	if innerpolicyKey == "priceDimensions" {
-				// 		for priceDimensionsKey, priceDimensionsValue := range innerpolicyValue.(map[string]interface{}) {
-				// 			cblogger.Info("priceDimensionsValue))))))))))))", priceDimensionsValue)
-
-				// 			pricingPolicy.PricingId = priceDimensionsKey
-				// 			pricingPolicy.PricingPolicy = termsKey
-				// 			pricingPolicy.Description = fmt.Sprintf("%s", priceDimensionsValue.(map[string]interface{})["description"])
-				// 			for key, val := range priceDimensionsValue.(map[string]interface{})["pricePerUnit"].(map[string]interface{}) {
-				// 				pricingPolicy.Currency = key
-				// 				pricingPolicy.Price = fmt.Sprintf("%s", val)
-				// 				// USD is Default.
-				// 				// if NO USD data, accept other currency.
-				// 				if key == "USD" {
-				// 					break
-				// 				}
-
-				// 			}
-				// 			pricingPolicy.Unit = fmt.Sprintf("%s", priceDimensionsValue.(map[string]interface{})["unit"])
-
-				// 		} // end of for
-				// 	} // end of priceDimensions
-
-				// 	if innerpolicyKey == "termAttributes" {
-				// 		cblogger.Info("terms ::: ", termsKey)
-				// 		cblogger.Info("termAttribute ::: ", innerpolicyValue)
-				// 		// innerpolicyMap := innerpolicyValue.(map[string]interface{})
-				// 		// if value, ok := innerpolicyMap["LeaseContractLength"]; ok {
-				// 		// 	leaseContractLength, ok := value.(string)
-				// 		// 	// 변수에 값이 성공적으로 담겼을 경우
-				// 		// 	if ok {
-				// 		// 		if hasLeaseContractLength && leaseContractLengthVal != value {
-				// 		// 			continue
-				// 		// 		}
-				// 		// 		cblogger.Info("LeaseContractLength 변수:", leaseContractLength)
-				// 		// 		//pricingPolicy.PricingPolicyInfo.LeaseContractLength = leaseContractLength
-				// 		// 	} else { // 타입 단언에 실패한 경우
-				// 		// 		cblogger.Info("LeaseContractLength의 데이터 타입을 가져올 수 없습니다.")
-				// 		// 		continue
-				// 		// 	}
-				// 		// } else {
-				// 		// 	// "LeaseContractLength" 키가 존재하지 않는 경우
-				// 		// 	cblogger.Info("LeaseContractLength 키가 존재하지 않습니다. ", innerpolicyValue)
-				// 		// 	continue
-				// 		// }
-
-				// 		// cblogger.Info("offeringClassVal = offeringClassVal ", offeringClassVal)
-				// 		// cblogger.Info("purchaseOptionVal = offeringClassVal ", purchaseOptionVal)
-				// 		// map[LeaseContractLength:1yr OfferingClass:convertible PurchaseOption:No Upfront]
-
-				// 		// pricingPolicy.PricingPolicyInfo.LeaseContractLength = fmt.Sprintf("%s", termAttributesValue.(map[string]interface{})["LeaseContractLength"])
-				// 		// pricingPolicy.PricingPolicyInfo.OfferingClass = fmt.Sprint("%s", innerpolicyValue.(map[string]interface{})["OfferingClass"])
-				// 		// pricingPolicy.PricingPolicyInfo.PurchaseOption = fmt.Sprint("%s", innerpolicyValue.(map[string]interface{})["PurchaseOption"])
-
-				// 		// for termAttributeskey, termAttributesValue := range innerpolicyValue.(map[string]interface{}) {
-				// 		// 	cblogger.Info("termAttributeskey!********", termAttributeskey)
-				// 		// 	cblogger.Info("termAttributesValue2////////", termAttributesValue) // TODO : map이 아니라 string값임.
-
-				// 		// if hasLeaseContractLength && leaseContractLengthVal !=
-				// 		// foundSku := false
-				// 		// cblogger.Info("go sku ", termAttributesValue)
-				// 		// for _, skukey := range termAttributesValue.(map[string]interface{}) {
-				// 		// 	cblogger.Info("skukey ", skukey)
-				// 		// 	// check filters
-				// 		// 	if hasLeaseContractLength && LeaseContractLengthVal == skukey {
-				// 		// 		foundSku = true
-				// 		// 		break
-				// 		// 	}
-				// 		// 	if hasOfferingClass && OfferingClassVal == skukey {
-				// 		// 		foundSku = true
-				// 		// 		break
-				// 		// 	}
-				// 		// 	if hasPurchaseOption && PurchaseOptionVal == skukey {
-				// 		// 		foundSku = true
-				// 		// 		break
-				// 		// 	}
-				// 		// 	cblogger.Info("end skukey ", skukey)
-
-				// 		// }
-				// 		// if hasLeaseContractLength && !foundSku { // sku를 못 찾았으면 skip.
-				// 		// 	cblogger.Info("filtered by Sku ", hasLeaseContractLength, foundSku)
-				// 		// 	continue
-				// 		// }
-				// 		// if hasOfferingClass && !foundSku { // sku를 못 찾았으면 skip.
-				// 		// 	cblogger.Info("filtered by Sku ", hasOfferingClass, foundSku)
-				// 		// 	continue
-				// 		// }
-				// 		// if hasPurchaseOption && !foundSku { // sku를 못 찾았으면 skip.
-				// 		// 	cblogger.Info("filtered by Sku ", hasPurchaseOption, foundSku)
-				// 		// 	continue
-				// 		// }
-
-				// 		// cblogger.Info("set leaseContractLength ", termAttributesValue.(map[string]interface{})["LeaseContractLength"])
-				// 		// 		spew.Dump("termAttributesValue.(map[string]interface{})[LeaseContractLength]5555555555", termAttributesValue.(map[string]interface{})["LeaseContractLength"])
-				// 		// 		spew.Dump("termAttributesValue6666666666", termAttributesValue)
-				// 		// pricingPolicy.PricingPolicyInfo.LeaseContractLength = fmt.Sprintf("%s", termAttributesValue.(map[string]interface{})["LeaseContractLength"])
-				// 		// pricingPolicy.PricingPolicyInfo.OfferingClass = fmt.Sprint("%s", innerpolicyValue.(map[string]interface{})["OfferingClass"])
-				// 		// pricingPolicy.PricingPolicyInfo.PurchaseOption = fmt.Sprint("%s", innerpolicyValue.(map[string]interface{})["PurchaseOption"])
-
-				// 		// }
-
-				// 		//cblogger.Info("LeaseContractLength !@!@!@!@!@", pricingPolicy.PricingPolicyInfo.LeaseContractLength)
-				// 	}
-
-				// } // end of innerpolicyKey
-
-				// aPrice, ok := priceMap[productId]
-
-				// if ok { // product가 존재하면 policy 추가
-				// 	cblogger.Info("product exist ", productId)
-				// 	aPrice.PriceInfo.PricingPolicies = append(aPrice.PriceInfo.PricingPolicies, pricingPolicy)
-				// 	// aPrice.PriceInfo.CSPPriceInfo = append(aPrice.PriceInfo.CSPPriceInfo.([]string), cspPriceInfo...)
-				// 	// var priceInfo irs.PriceInfo
-				// 	// priceInfo.CSPPriceInfo = price["terms"]
-				// 	priceMap[productId] = aPrice
-
-				// } else { // product가 없으면 price 추가
-				// 	cblogger.Info("product not exist ", productId)
-
-				// 	newPriceInfo := irs.PriceInfo{}
-				// 	newPolicies := []irs.PricingPolicies{}
-				// 	newPolicies = append(newPolicies, pricingPolicy)
-
-				// 	newPriceInfo.PricingPolicies = newPolicies
-				// 	newPriceInfo.CSPPriceInfo = price["terms"] // 새로운 가격이면 terms아래값을 넣는다.
-
-				// 	// newCSPPriceInfo := []string{}
-				// 	// newCSPPriceInfo = append(newCSPPriceInfo, priceResponseStr)
-				// 	// newPriceInfo.CSPPriceInfo = newCSPPriceIn
-				// 	newPrice := irs.Price{}
-				// 	newPrice.PriceInfo = newPriceInfo
-				// 	newPrice.ProductInfo = productInfo
-
-				// 	priceMap[productId] = newPrice
-				// }
 			}
 		}
-
-		// price info
-		// var priceListone irs.Price
-		// priceListone.ProductInfo = productInfo
-		// priceListone.PriceInfo = priceInfo
 	}
 
 	priceList := []irs.Price{}
@@ -492,7 +196,7 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 	priceone := irs.CloudPrice{
 		CloudName: "AWS",
 	}
-	// priceone.PriceList = append(priceone.PriceList, priceList...)
+
 	priceone.PriceList = priceList
 	result.CloudPriceList = append(result.CloudPriceList, priceone)
 
@@ -501,7 +205,6 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 		cblogger.Error(err)
 		return "", err
 	}
-	cblogger.Info("return ", string(resultString))
 	return string(resultString), nil
 }
 
@@ -509,7 +212,6 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 func ExtractProductInfo(jsonValue aws.JSONValue) (irs.ProductInfo, error) {
 	var productInfo irs.ProductInfo
 
-	cblogger.Info("=-=-=-=-=-=-=-=-", jsonValue)
 	jsonString, err := json.MarshalIndent(jsonValue["product"].(map[string]interface{})["attributes"], "", "    ")
 	if err != nil {
 		cblogger.Error(err)
@@ -634,14 +336,6 @@ func setProductsInputRequestFilter(filterList []irs.KeyValue) ([]*pricing.Filter
 					Value: aws.String(filter.Value),
 				})
 			}
-			// if filter.Key == "leaseContractLength" {
-			// 	requestFilters = append(requestFilters, &pricing.Filter{
-			// 		Field: aws.String("leaseContractLength"),
-			// 		Type:  aws.String("TERM_MATCH"),
-			// 		Value: aws.String(filter.Value),
-			// 	})
-			// }
-
 		} //end of for
 	} // end of if
 	return requestFilters, nil
@@ -662,11 +356,8 @@ func OnDemandPolicyFilter(priceDimensionsKey string, priceDimensions map[string]
 
 	// reserved only options
 	hasLeaseContractLength := false
-	//leaseContractLengthVal := ""
 	hasOfferingClass := false
-	//offeringClassVal := ""
 	hasPurchaseOption := false
-	//purchaseOptionVal := ""
 
 	if filterList != nil {
 
@@ -690,22 +381,18 @@ func OnDemandPolicyFilter(priceDimensionsKey string, priceDimensions map[string]
 			}
 			if filter.Key == "leaseContractLength" {
 				hasLeaseContractLength = true
-				// leaseContractLengthVal = filter.Value
 				break
 			}
 			if filter.Key == "offeringClass" {
 				hasOfferingClass = true
-				// offeringClassVal = filter.Value
 				break
 			}
 			if filter.Key == "purchaseOption" {
 				hasPurchaseOption = true
-				// purchaseOptionVal = filter.Value
 				break
 			}
 		}
 		// check filters
-
 	}
 
 	if hasLeaseContractLength || hasOfferingClass || hasPurchaseOption { // reserved 전용 filter 임.
@@ -713,8 +400,7 @@ func OnDemandPolicyFilter(priceDimensionsKey string, priceDimensions map[string]
 		return true
 	}
 
-	if hasPricingPolicy { //
-		//if pricingPolicyVal != priceDimensions["pricingPolicy"] {
+	if hasPricingPolicy {
 		if pricingPolicyVal != "OnDemand" {
 			cblogger.Info("filtered by pricingPolicy ", pricingPolicyVal, priceDimensions["pricingPolicy"])
 			return true
@@ -740,11 +426,6 @@ func OnDemandPolicyFilter(priceDimensionsKey string, priceDimensions map[string]
 			return true
 		}
 	}
-
-	cblogger.Info("1.pricingPolicyVal ", pricingPolicyVal, hasPricingPolicy, priceDimensions["pricingPolicy"])
-	cblogger.Info("2.priceDemensionVal ", priceDemensionVal, hasPriceDimension, priceDimensionsKey)
-	cblogger.Info("3.unitVal ", unitVal, hasUnit)
-
 	return isFiltered
 }
 
@@ -810,14 +491,12 @@ func ReservedPolicyFilter(priceDimensionsKey string, priceDimensionsValue map[st
 
 	if hasPriceDimension {
 		if priceDemensionVal != priceDimensionsKey { // priceId
-			cblogger.Info("filtered by priceDimension ", priceDemensionVal, priceDimensionsKey)
 			return true
 		}
 	}
 
 	if hasPricingPolicy {
 		if pricingPolicyVal != "Reserved" {
-			cblogger.Info("filtered by pricingPolicy reserved only ", pricingPolicyVal)
 			return true
 		}
 	}
@@ -836,25 +515,20 @@ func ReservedPolicyFilter(priceDimensionsKey string, priceDimensionsValue map[st
 	}
 
 	if hasLeaseContractLength {
-		if leaseContractLengthVal != termAttributes["LeaseContractLength"] { // 계약 기간 : 1yr, 3yr ...
-			cblogger.Info("filtered by LeaseContractLength ", priceDemensionVal, termAttributes["LeaseContractLength"])
+		if leaseContractLengthVal != termAttributes["LeaseContractLength"] {
 			return true
 		}
 	}
 
 	if hasOfferingClass {
-		if offeringClassVal != termAttributes["OfferingClass"] { // 계약 종류 : standard, convertible ...
-			cblogger.Info("filtered by OfferingClass ", offeringClassVal, termAttributes["OfferingClass"])
+		if offeringClassVal != termAttributes["OfferingClass"] {
 			return true
 		}
 	}
-
-	cblogger.Info("11.pricingPolicyVal ", pricingPolicyVal, hasPricingPolicy)
-	cblogger.Info("22.priceDemensionVal ", priceDemensionVal, hasPriceDimension)
-	cblogger.Info("33.unitVal ", unitVal, hasUnit)
-	cblogger.Info("44.leaseContractLengthVal ", leaseContractLengthVal, hasLeaseContractLength)
-	cblogger.Info("55.offeringClassVal ", offeringClassVal, hasOfferingClass)
-	cblogger.Info("66.purchaseOptionVal ", purchaseOptionVal, hasPurchaseOption)
-
+	if hasPurchaseOption {
+		if purchaseOptionVal != termAttributes["PurchaseOption"] {
+			return true
+		}
+	}
 	return isFiltered
 }

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/RegionZoneHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/RegionZoneHandler.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/davecgh/go-spew/spew"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 
@@ -39,7 +40,7 @@ func (regionZoneHandler *AwsRegionZoneHandler) ListRegionZone() ([]*irs.RegionZo
 			}
 			tempclient := ec2.New(sess)
 
-			responseZones, err := DescribeAvailabilityZones(tempclient, true)
+			responseZones, err := DescribeAvailabilityZones(tempclient, false)
 			if err != nil {
 				cblogger.Errorf("AuthFailure on [%s]", *region.RegionName)
 				cblogger.Error(err)
@@ -89,7 +90,7 @@ func (regionZoneHandler *AwsRegionZoneHandler) ListRegionZone() ([]*irs.RegionZo
 }
 
 func (regionZoneHandler *AwsRegionZoneHandler) GetRegionZone(Name string) (irs.RegionZoneInfo, error) {
-	responseRegions, err := DescribeRegions(regionZoneHandler.Client, true, Name)
+	responseRegions, err := DescribeRegions(regionZoneHandler.Client, false, Name)
 	if err != nil {
 		cblogger.Error(err)
 		return irs.RegionZoneInfo{}, err
@@ -97,15 +98,18 @@ func (regionZoneHandler *AwsRegionZoneHandler) GetRegionZone(Name string) (irs.R
 
 	var regionZoneInfo irs.RegionZoneInfo
 	for _, region := range responseRegions.Regions {
+		spew.Dump("####################", region.RegionName)
 		sess, err := session.NewSession(&aws.Config{
 			Region: region.RegionName,
+			//Region: aws.String("us-west-1"),
+
 		})
 		if err != nil {
 			cblogger.Error(err)
 		}
 		tempclient := ec2.New(sess)
 
-		responseZones, err := DescribeAvailabilityZones(tempclient, true)
+		responseZones, err := DescribeAvailabilityZones(tempclient, false)
 		if err != nil {
 			cblogger.Errorf("AuthFailure on [%s]", *region.RegionName)
 			cblogger.Error(err)
@@ -182,7 +186,7 @@ func (regionZoneHandler *AwsRegionZoneHandler) ListOrgZone() (string, error) {
 		} else {
 			tempclient := ec2.New(sess)
 
-			responseZones, err := DescribeAvailabilityZones(tempclient, true)
+			responseZones, err := DescribeAvailabilityZones(tempclient, false)
 			if err != nil {
 				cblogger.Errorf("DescribeAvailabilityZones err %s", *region.RegionName)
 				cblogger.Error(err)


### PR DESCRIPTION
# AWS 드라이버 특이사항

### ListProductFamily

- 별도 컴퓨팅 인프라 환경 제공하는 SDK 존재하지 않음 → 하드코딩
    
    ```
    var result []string
    
    	result = append(result, "AmazonEC2")
    	return result, nil
    ```
    

### GetPriceInfo

- AdminWeb상에서 **Pricing Information 관련 필터 적용시 소스상 필터 후처리로 인해 AWS Price Info에는 모든 결과 값들이 나올 수 있음**
    - product에는 필터 적용된 값만 정상적으로 출력
- InstanceType + OS 를 포함한 것이 한 개의 product
    - 각 product는 고유의 sku를 가지고 있다.
    - product는 여러개의 Terms를 가지고 있다.
    - terms는 OnDemand, Reserved 두가지 type이 있으며
    각 type별로 정책에 따른 가격이 여러개 있을 수 있다.


---
# AWS Driver Details

### ListProductFamily

- SDK not present in separate computing infrastructure environment → hardcoding
    
    ```
    var result []string
    
    	result = append(result, "AmazonEC2")
    	return result, nil
    ```
    

 ### GetPriceInfo

- **When applying the Pruning Information-related filter on the Admin Web, AWS Price Info may have all the result values due to the post-processing of the filter on the source**
    - Only filter applied values are output normally to the product
- One product with InstanceType + OS
    - Each product has its own sku.
    - The product has several Term's.
    - There are two types of terms: OnDemand and Reserved
    There may be several prices according to the policy for each type.
