### PR TITLE
[AWS] Expansion of zone-based resource control functionality. Issue 1067

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/DiskHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/DiskHandler.go
@@ -61,7 +61,11 @@ func (DiskHandler *AwsDiskHandler) CreateDisk(diskReqInfo irs.DiskInfo) (irs.Dis
 	start := call.Start()
 
 	zone := DiskHandler.Region.Zone
-	spew.Dump(DiskHandler.Region)
+
+	if diskReqInfo.Zone != ""{
+		zone = diskReqInfo.Zone
+	}
+	//spew.Dump(DiskHandler.Region)
 	err := validateCreateDisk(&diskReqInfo)
 	if err != nil {
 		return irs.DiskInfo{}, err
@@ -104,7 +108,7 @@ func (DiskHandler *AwsDiskHandler) CreateDisk(diskReqInfo irs.DiskInfo) (irs.Dis
 	// case3 : 암호화된 disk 생성
 	//input.Encrypted = true
 	//input.KmsKeyId = ""
-	spew.Dump(input)
+	//spew.Dump(input)
 	result, err := DiskHandler.Client.CreateVolume(input)
 	hiscallInfo.ElapsedTime = call.Elapsed(start)
 	if err != nil {
@@ -331,7 +335,7 @@ func (DiskHandler *AwsDiskHandler) AttachDisk(diskIID irs.IID, ownerVM irs.IID) 
 		return irs.DiskInfo{}, err
 	}
 
-	spew.Dump(diskDeviceList)
+	//spew.Dump(diskDeviceList)
 	if diskDeviceList != nil {
 		isAvailable := true
 		for _, avn := range availableVolumeNames {
@@ -890,7 +894,7 @@ func (DiskHandler *AwsDiskHandler) convertVolumeInfoToDiskInfo(volumeInfo *ec2.V
 	}
 
 	diskInfo.CreatedTime = *volumeInfo.CreateTime
-	spew.Dump(volumeInfo)
+	//spew.Dump(volumeInfo)
 	//KeyValueList []KeyValue
 	var inKeyValueList []irs.KeyValue
 	//if !reflect.ValueOf(volumeInfo.Encrypted).IsNil() {


### PR DESCRIPTION
[AWS] Zone-based 자원 제어 기능 확장

VPC는 Region base, Subnet은 zone base 이므로
subnet 생성시 zone parameter가 있으면 해당 zone을 사용하도록 보완.
VPCs are based on Regions and Subnets are based on zones, when creating a subnet, if a zone parameter is provided, it should be adjusted to use the specified zone

	if reqSubnetInfo.Zone != ""{
		zoneId = reqSubnetInfo.Zone
	}

Disk는 zone base이므로 생성시 zone parameter가 있으면 해당 zone을 사용하도록 보완.
Disks are based on zones, when creating a disk, if a zone parameter is provided, it should be adjusted to use the specified zone.
	if diskReqInfo.Zone != ""{
		zone = diskReqInfo.Zone
	}