### PR TITLE
gcp cluster handler - add keypair iid to node info

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/CommonHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/CommonHandler.go
@@ -554,7 +554,7 @@ func WaitContainerOperationFail(client *container.Service, project string, regio
 		after_time := time.Now()
 		diff := after_time.Sub(before_time)
 		if int(diff.Seconds()) > max_time {
-			cblogger.Errorf("Forcing termination of Wait because the status of resource [%s] has not completed within [%d] seconds.", max_time, resourceId)
+			cblogger.Infof("Forcing termination of Wait because the status of resource [%s] has not failed within [%d] seconds.", resourceId, max_time)
 			return nil
 		}
 	}

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/CommonHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/CommonHandler.go
@@ -536,7 +536,10 @@ func WaitContainerOperationFail(client *container.Service, project string, regio
 			return err
 		}
 		cblogger.Debug(opSatus)
-		cblogger.Infof("==> Status: Progress: [%d] / [%s]", opSatus.Progress, opSatus.Status)
+
+		if opSatus.Progress != nil && len(opSatus.Progress.Metrics) > 0 && opSatus.Progress.Metrics[0] != nil {
+			cblogger.Infof("==> Status: Progress: [%d] / [%s]", opSatus.Progress.Metrics[0].IntValue, opSatus.Status)
+		}
 
 		//PENDING, RUNNING, or DONE.
 


### PR DESCRIPTION
## 작업 내용
- gcp 에서 클러스터 생성 시 node group 을 추가해서 cluster 를 생성하는 경우, node pool 에 등록되는 label 로 keypair iid 제공
- type 2 ( cluster 생성 시 node group 을 같이 생성) 만 지원하도록 node group list 의 길이가 0보다 큰 경우에만 cluster 생성 가능 하도록 validation 추가
- 적절한 log format 과 level 로 수정