### PR TITLE
initialize aws cost explorer getCostAndUsageWithResource anycall handler function

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/aws/AwsDriver.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/AwsDriver.go
@@ -302,34 +302,9 @@ func getPricingClient(connectionInfo idrv.ConnectionInfo) (*pricing.Pricing, err
 }
 
 func getCostExplorerClient(connectionInfo idrv.ConnectionInfo) (*costexplorer.CostExplorer, error) {
-
-	// "us-east-1", "eu-central-1", "ap-south-1" 3개 리전의 엔드포인트만 지원
-	// AWS 리전은 Price List Query API의 API 엔드포인트입니다.
-	// 엔드포인트는 제품 또는 서비스 속성과 관련이 없습니다.
-	// https://docs.aws.amazon.com/ko_kr/awsaccountbilling/latest/aboutv2/using-price-list-query-api.html#price-list-query-api-endpoints
-
-	costExplorerRegion := []string{"us-east-1"}
-	match := false
-	for _, str := range costExplorerRegion {
-		if str == connectionInfo.RegionInfo.Region {
-			match = true
-			break
-		}
-	}
-
-	var targetRegion string
-	if match {
-		targetRegion = connectionInfo.RegionInfo.Region
-	} else {
-		targetRegion = "us-east-1"
-	}
-
 	sess := session.Must(session.NewSession())
-	// Create a Pricing client with additional configuration
 	svc := costexplorer.New(sess, &aws.Config{
-		// Region: aws.String(connectionInfo.RegionInfo.Region),
-		Region: aws.String(targetRegion),
-		//Region:      aws.String("ap-northeast-2"),
+		Region:      aws.String(connectionInfo.RegionInfo.Region),
 		Credentials: credentials.NewStaticCredentials(connectionInfo.CredentialInfo.ClientId, connectionInfo.CredentialInfo.ClientSecret, "")},
 	)
 

--- a/cloud-control-manager/cloud-driver/drivers/aws/connect/AwsCloudConnection.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/connect/AwsCloudConnection.go
@@ -21,6 +21,7 @@ import (
 	ars "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/aws/resources"
 
 	//ec2drv "github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/costexplorer"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/pricing"
@@ -62,6 +63,8 @@ type AwsCloudConnection struct {
 
 	AnyCallClient *ec2.EC2
 	TagClient     *ec2.EC2
+
+	CostExplorerClient *costexplorer.CostExplorer
 }
 
 var cblogger *logrus.Logger
@@ -186,7 +189,7 @@ func (cloudConn *AwsCloudConnection) CreateClusterHandler() (irs.ClusterHandler,
 }
 
 func (cloudConn *AwsCloudConnection) CreateAnyCallHandler() (irs.AnyCallHandler, error) {
-	handler := ars.AwsAnyCallHandler{Region: cloudConn.Region, CredentialInfo: cloudConn.CredentialInfo, Client: cloudConn.AnyCallClient}
+	handler := ars.AwsAnyCallHandler{Region: cloudConn.Region, CredentialInfo: cloudConn.CredentialInfo, Client: cloudConn.AnyCallClient, CeClient: cloudConn.CostExplorerClient}
 	return &handler, nil
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/AnyCallHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/AnyCallHandler.go
@@ -11,6 +11,7 @@
 package resources
 
 import (
+	"context"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
@@ -19,8 +20,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/costexplorer"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
 	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
@@ -30,19 +33,24 @@ type AwsAnyCallHandler struct {
 	Region         idrv.RegionInfo
 	CredentialInfo idrv.CredentialInfo
 	Client         *ec2.EC2
+	CeClient       *costexplorer.CostExplorer
 }
 
-/********************************************************
-        // call example
-        curl -sX POST http://localhost:1024/spider/anycall -H 'Content-Type: application/json' -d \
-        '{
-                "ConnectionName" : "aws-ohio-config",
-                "ReqInfo" : {
-                        "FID" : "createTags",
-                        "IKeyValueList" : [{"Key":"key1", "Value":"value1"}, {"Key":"key2", "Value":"value2"}]
-                }
-        }' | json_pp
-********************************************************/
+/*
+*******************************************************
+
+	// call example
+	curl -sX POST http://localhost:1024/spider/anycall -H 'Content-Type: application/json' -d \
+	'{
+	        "ConnectionName" : "aws-ohio-config",
+	        "ReqInfo" : {
+	                "FID" : "createTags",
+	                "IKeyValueList" : [{"Key":"key1", "Value":"value1"}, {"Key":"key2", "Value":"value2"}]
+	        }
+	}' | json_pp
+
+*******************************************************
+*/
 func (anyCallHandler *AwsAnyCallHandler) AnyCall(callInfo irs.AnyCallInfo) (irs.AnyCallInfo, error) {
 	cblogger.Info("AWS Driver: called AnyCall()!")
 
@@ -53,16 +61,17 @@ func (anyCallHandler *AwsAnyCallHandler) AnyCall(callInfo irs.AnyCallInfo) (irs.
 		return associateIamInstanceProfile(anyCallHandler, callInfo)
 	case "getRegionInfo":
 		return getRegionInfo(anyCallHandler, callInfo)
-	// add more ...
+	case "getCostWithResource":
+		return getCostWithResource(anyCallHandler, callInfo)
 
 	default:
 		return irs.AnyCallInfo{}, errors.New("AWS Driver: " + callInfo.FID + " Function is not implemented!")
 	}
 }
 
-///////////////////////////////////////////////////////////////////////
+// /////////////////////////////////////////////////////////////////////
 // implemented by developer user, like 'createTags(kv []KeyVale) bool'
-///////////////////////////////////////////////////////////////////////
+// /////////////////////////////////////////////////////////////////////
 const (
 	CreateTagsResourceId = "ResourceId"
 	CreateTagsTag        = "Tag"
@@ -131,9 +140,9 @@ const (
 	AssociateIamInstanceProfileRole       = "Role"
 )
 
-///////////////////////////////////////////////////////////////////
+// /////////////////////////////////////////////////////////////////
 // implemented by developer user, like 'associateIamInstanceProfile(kv []KeyValue) bool'
-///////////////////////////////////////////////////////////////////
+// /////////////////////////////////////////////////////////////////
 func associateIamInstanceProfile(anyCallHandler *AwsAnyCallHandler, callInfo irs.AnyCallInfo) (irs.AnyCallInfo, error) {
 	cblogger.Info("AWS Driver: called AnyCall()/associateIamInstanceProfile()!")
 
@@ -231,4 +240,171 @@ func encrypt(contents []byte) ([]byte, error) {
 	cipherTextFB.XORKeyStream(encryptData[aes.BlockSize:], []byte(contents))
 
 	return encryptData, nil
+}
+
+type CostWithResourceReq struct {
+	StartDate   string           `json:"startDate"`
+	EndDate     string           `json:"endDate"`
+	Granularity string           `json:"granularity"`
+	Metrics     []string         `json:"metrics"`
+	Filter      FilterExpression `json:"filter"`
+	Groups      []GroupBy        `json:"groups"`
+}
+
+type FilterExpression struct {
+	And            []*FilterExpression `json:"and,omitempty"`
+	Or             []*FilterExpression `json:"or,omitempty"`
+	Not            *FilterExpression   `json:"not,omitempty"`
+	CostCategories *KeyValues          `json:"costCategories,omitempty"`
+	Dimensions     *KeyValues          `json:"dimensions,omitempty"`
+	Tags           *KeyValues          `json:"tags,omitempty"`
+}
+
+type KeyValues struct {
+	Key    string   `json:"key"`
+	Values []string `json:"values"`
+}
+
+type GroupBy struct {
+	Key  string `json:"key"`
+	Type string `json:"type"` // DIMENSION | TAG | COST_CATEGORY
+}
+
+func getCostWithResource(anyCallHandler *AwsAnyCallHandler, callInfo irs.AnyCallInfo) (irs.AnyCallInfo, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	reqMap := mapToKeyValue(callInfo.IKeyValueList)
+	body, ok := reqMap["requestBody"]
+	if !ok {
+		return callInfo, errors.New("requestBody is required")
+	}
+
+	var costWithResourceReq CostWithResourceReq
+	err := json.Unmarshal([]byte(body), &costWithResourceReq)
+	if err != nil {
+		return callInfo, err
+	}
+
+	startDate := costWithResourceReq.StartDate
+	endDate := costWithResourceReq.EndDate
+	granularity := costWithResourceReq.Granularity
+	metric := costWithResourceReq.Metrics
+	filter := convertToExpression(&costWithResourceReq.Filter)
+	group := groupGenerate(costWithResourceReq.Groups)
+
+	input := &costexplorer.GetCostAndUsageWithResourcesInput{
+		TimePeriod: &costexplorer.DateInterval{
+			Start: aws.String(startDate),
+			End:   aws.String(endDate),
+		},
+		Granularity: aws.String(granularity),
+		Metrics:     aws.StringSlice(metric),
+		Filter:      filter,
+		GroupBy:     group,
+	}
+
+	res, err := anyCallHandler.CeClient.GetCostAndUsageWithResourcesWithContext(ctx, input)
+	if err != nil {
+		cblogger.Error("error occur", err)
+		return callInfo, err
+	}
+
+	m, err := json.Marshal(res)
+	if err != nil {
+
+		return callInfo, err
+	}
+
+	callInfo.OKeyValueList = []irs.KeyValue{
+		{
+			Key:   "result",
+			Value: string(m),
+		},
+	}
+	return callInfo, nil
+}
+
+func convertToExpression(filter *FilterExpression) *costexplorer.Expression {
+	if filter == nil {
+		return nil
+	}
+
+	expression := &costexplorer.Expression{
+		CostCategories: convertKeyValuesToCostCategoryValues(filter.CostCategories),
+		Dimensions:     convertKeyValuesToDimensionValues(filter.Dimensions),
+		Tags:           convertKeyValuesToTagValues(filter.Tags),
+	}
+
+	if len(filter.And) > 0 {
+		expression.And = make([]*costexplorer.Expression, len(filter.And))
+		for i, f := range filter.And {
+			expression.And[i] = convertToExpression(f)
+		}
+	}
+
+	if len(filter.Or) > 0 {
+		expression.Or = make([]*costexplorer.Expression, len(filter.Or))
+		for i, f := range filter.Or {
+			expression.Or[i] = convertToExpression(f)
+		}
+	}
+
+	if filter.Not != nil {
+		expression.Not = convertToExpression(filter.Not)
+	}
+
+	return expression
+}
+
+func convertKeyValuesToCostCategoryValues(kv *KeyValues) *costexplorer.CostCategoryValues {
+	if kv == nil {
+		return nil
+	}
+	return &costexplorer.CostCategoryValues{
+		Key:    aws.String(kv.Key),
+		Values: aws.StringSlice(kv.Values),
+	}
+}
+
+func convertKeyValuesToDimensionValues(kv *KeyValues) *costexplorer.DimensionValues {
+	if kv == nil {
+		return nil
+	}
+	return &costexplorer.DimensionValues{
+		Key:    aws.String(kv.Key),
+		Values: aws.StringSlice(kv.Values),
+	}
+}
+
+func convertKeyValuesToTagValues(kv *KeyValues) *costexplorer.TagValues {
+	if kv == nil {
+		return nil
+	}
+	return &costexplorer.TagValues{
+		Key:    aws.String(kv.Key),
+		Values: aws.StringSlice(kv.Values),
+	}
+}
+
+func groupGenerate(g []GroupBy) []*costexplorer.GroupDefinition {
+	var groupBy []*costexplorer.GroupDefinition
+	for _, v := range g {
+		groupBy = append(groupBy, &costexplorer.GroupDefinition{
+			Key:  aws.String(v.Key),
+			Type: aws.String(v.Type),
+		})
+	}
+
+	return groupBy
+}
+
+func mapToKeyValue(kvs []irs.KeyValue) map[string]string {
+	filterMap := make(map[string]string, 0)
+
+	for _, kv := range kvs {
+		filterMap[kv.Key] = kv.Value
+	}
+	return filterMap
+
 }


### PR DESCRIPTION
## 작업 내용
- aws cost explorer 사용을 위해 aws anycall handler 에 cost exeplorer client 추가
- aws cost explorer 의 getCostAndUsageWithResources 호출을 위한 함수 구현

---

## 개요
getCostWithResource 함수는 지정된 매개변수에 따라 AWS Cost Explorer에서 AWS 리소스의 비용 및 사용량 데이터를 쿼리한다. spider 의 aws anycall handler 를 확장해서 기능을 구성했다.

## 함수 시그니처
```go
func getCostWithResource(anyCallHandler *AwsAnyCallHandler, callInfo irs.AnyCallInfo) (irs.AnyCallInfo, error)
```

## 매개변수
**`anyCallHandler`**
- 타입: *AwsAnyCallHandler
- 설명: AWS 호출 핸들러로, AWS Cost Explorer 클라이언트에 접근 가능

**`callInfo`**
- 타입: irs.AnyCallInfo
- 설명: 요청에 대한 정보를 포함하며, 응답으로 업데이트

## 요청 구조 ‼️🎆✨
callInfo 매개변수는 **requestBody** 키 아래에 JSON 본문을 포함해야 한다. 이 JSON은 `CostWithResourceReq `구조에 맞아야하며 `CostWithResourceReq `는 다음과 같은 구조를 가진다.

### CostWithResourceReq 구조

**`StartDate: string`**  required
- 설명: 비용 및 사용량 보고서의 시작 날짜 (형식: YYYY-MM-DD)
- 조회 조건에 포함

**`EndDate: string`**  required
- 설명: 비용 및 사용량 보고서의 종료 날짜 (형식: YYYY-MM-DD)
- 조회 조건에 미포함 - 2024-10-10 이라고 한 경우 2024-10-09 까지의 데이터만 제공

**`Granularity: string`**  required
- 설명: 데이터의 세분성 (HOURLY | DAILY | MONTHLY).
- Hourly 는 오늘 기준 최대 14일 이내의 데이터만 조회 가능

**`Metrics: []string`**  required at least one element
- 설명: 검색할 메트릭 목록 (AmortizedCost | BlendedCost | NetAmortizedCost | NetUnblendedCost | NormalizedUsageAmount | UnblendedCost | UsageQuantity).

**`Filter: FilterExpression`**  required
- 설명: 데이터에 적용할 필터.

**`Groups: []GroupBy`**  optional
- 설명: 보고서의 그룹화 목록.

### FilterExpression 구조

**`And: []*FilterExpression`** optional
- 설명: 필터의 논리적 AND.
- 재귀적으로 FilterExpression 구성

**`Or: []*FilterExpression`** optional
- 설명: 필터의 논리적 OR.
- 재귀적으로 FilterExpression 구성

**`Not: *FilterExpression`** optional
- 설명: 필터의 논리적 NOT.
- 재귀적으로 FilterExpression 구성

**`CostCategories: *KeyValues`** optional
- 설명: 필터링할 비용 카테고리.

**`Dimensions: *KeyValues`** optional
- 설명: 필터링할 차원.
- Demension.SERVICE 타입으로 사용 가능한 리스트
	- AWS Glue
	- AWS Key Management Service
	- AWS Lambda
	- AWS Migration Hub Refactor Spaces
	- AWS Secrets Manager
	- AWS Step Functions
	- AWS Systems Manager
	- Amazon API Gateway
	- Amazon EC2 Container Registry (ECR)
	- Amazon Elastic Compute Cloud - Compute
	- Amazon Elastic Container Service for Kubernetes
	- Amazon Elastic Load Balancing
	- Amazon Lightsail
	- Amazon Location Service
	- Amazon Registrar
	- Amazon Relational Database Service
	- Amazon Route 53
	- Amazon Simple Notification Service
	- Amazon Simple Queue Service
	- Amazon Simple Storage Service
	- Amazon Virtual Private Cloud
	- AmazonCloudWatch
	- AWS Cost Explorer
	- EC2 - Other
	- Tax

**`Tags: *KeyValues`** optional
- 설명: 필터링할 태그.


### KeyValues 구조
**`Key: string`**
- 설명: 필터의 키.

**`Values: []string`**
- 설명: 키에 대한 값 목록.

### GroupBy 구조
**`Type: string`**
- 설명: 그룹화의 유형 (DIMENSION | TAG | COST_CATEGORY)

**`Key: string`**
- 설명: 그룹화할 키.
- DIMENSION 의 경우 사용 가능한 keys
  - AZ | INSTANCE_TYPE | LEGAL_ENTITY_NAME | INVOICING_ENTITY  | LINKED_ACCOUNT | OPERATION | PLATFORM | PURCHASE_TYPE | SERVICE | TENANCY | RECORD_TYPE | USAGE_TYPE



## 응답

함수는 AWS Cost Explorer의 응답으로 callInfo를 업데이트 한 후 리턴한다.

**`callInfo.OKeyValueList`**
키: "result"
값: AWS Cost Explorer 응답의 JSON 문자열.

## 오류
다음 경우에 오류를 반환한다.
- callInfo에 requestBody가 누락된 경우.
- JSON 언마샬링에 실패한 경우.
- AWS Cost Explorer API 호출에 실패한 경우.

## 요청 json 직렬화 형식 예시
```json
{
  "startDate": "2024-08-14",
  "endDate": "2024-08-28",
  "granularity": "DAILY",
  "metrics": [
    "UnblendedCost", "BlendedCost"
  ],
  "filter": {
    "or": [
      {
        "and": [
          {
            "dimensions": {
              "key": "RESOURCE_ID",
              "values": [
                "i-0xxxxxxxxxec4",
                "i-0xxx1e3",
                "arn:aws:ec2:ap-northeast-2:xxxxxx:network-interface/eni-06cxxxxxx02e34",
                "vol-068xxxxx0",
                "vol-0xxxx"
              ]
            }
          },
          {
            "dimensions": {
              "key": "SERVICE",
              "values": [
                "Amazon Elastic Compute Cloud - Compute",
                "EC2 - Other",
                "Amazon Virtual Private Cloud",
                "EC2 - Other"
              ]
            }
          }
        ]
      },
      {
        "dimensions": {
          "key": "SERVICE",
          "values": [
            "AWS Cost Explorer",
            "Tax"
          ]
        }
      }
    ]
  },
  "groups": [
    {
      "key": "SERVICE",
      "type": "DIMENSION"
    },
    {
      "key": "RESOURCE_ID",
      "type": "DIMENSION"
    }
  ]
}
```


## Curl 호출 예시
```bash
curl -X POST http://localhost:1024/spider/anycall \
  -H "Content-Type: application/json" \
  -d '{
    "ConnectionName": "your_connection_name",
    "ReqInfo": {
      "FID": "getCostWithResource",
      "IKeyValueList": [
        {
          "Key": "requestBody",
          "Value": "{\"startDate\":\"2024-08-14\",\"endDate\":\"2024-08-28\",\"granularity\":\"DAILY\",\"metrics\":[\"UnblendedCost\",\"BlendedCost\"],\"filter\":{\"or\":[{\"and\":[{\"dimensions\":{\"key\":\"RESOURCE_ID\",\"values\":[\"i-0xxxxxxxxxec4\",\"i-0xxx1e3\",\"arn:aws:ec2:ap-northeast-2:xxxxxx:network-interface/eni-06cxxxxxx02e34\",\"vol-068xxxxx0\",\"vol-0xxxx\"]}},{\"dimensions\":{\"key\":\"SERVICE\",\"values\":[\"Amazon Elastic Compute Cloud - Compute\",\"EC2 - Other\",\"Amazon Virtual Private Cloud\",\"EC2 - Other\"]}}]},{\"dimensions\":{\"key\":\"SERVICE\",\"values\":[\"AWS Cost Explorer\",\"Tax\"]}}]},\"groups\":[{\"key\":\"SERVICE\",\"type\":\"DIMENSION\"},{\"key\":\"RESOURCE_ID\",\"type\":\"DIMENSION\"}]}"
        }
      ]
    }
  }'

```




## GO 코드 예시
```go
costWithResourceReq := costWithResourceReq{
	StartDate:   param.StartDate.Format("2006-01-02"),
	EndDate:     param.EndDate.Format("2006-01-02"),
	Granularity: granularity,
	Metrics:     []string{metrics}, // BlendedCost, UnblendedCost, ...
	Filter: filterExpression{
		Or: []*filterExpression{
			{
				And: []*filterExpression{
					{
						Dimensions: &keyValues{
							Key:    "RESOURCE_ID",
							Values: resourceIdFilterValue,
						},
					},
					{
						Dimensions: &keyValues{
							Key:    "SERVICE",
							Values: serviceFilterValue,
						},
					},
				},
			},
			{
				Dimensions: &keyValues{
					Key: "SERVICE",
					Values: []string{
						string(constant.AwsCostExplorer),
						string(constant.AwsTax),
					},
				},
			},
		},
	},
	// the order of group by will effect the result's key order
	Groups: []groupBy{
		{
			Key:  "SERVICE",
			Type: "DIMENSION",
		},
		{
			Key:  "RESOURCE_ID",
			Type: "DIMENSION",
		},
	},
}

m, err := json.Marshal(costWithResourceReq)
if err != nil {
	return nil, err
}

res, err := spider.GetCostWithResourceWithContext(
	ctx,
	spider.AnycallReq{
		ConnectionName: param.ConnectionName,
		ReqInfo: spider.ReqInfo{
			FID: "getCostWithResource",
			IKeyValueList: []spider.KeyValue{
				{
					Key:   "requestBody",
					Value: string(m),
				},
			},
		},
	},
)
```


## 응답 예시
```json
{
  "DimensionValueAttributes": [],
  "GroupDefinitions": [
    {
      "Key": "SERVICE",
      "Type": "DIMENSION"
    },
    {
      "Key": "RESOURCE_ID",
      "Type": "DIMENSION"
    }
  ],
  "NextPageToken": null,
  "ResultsByTime": [
    {
      "Estimated": true,
      "Groups": [
        {
          "Keys": [
            "EC2 - Other",
            "i-xxxxxxxx"
          ],
          "Metrics": {
            "UnblendedCost": {
              "Amount": "0.000001897",
              "Unit": "USD"
            }
          }
        },
        {
          "Keys": [
            "EC2 - Other",
            "i-xxxxxx"
          ],
          "Metrics": {
            "UnblendedCost": {
              "Amount": "0.0050821397",
              "Unit": "USD"
            }
          }
        },
        {
          "Keys": [
            "EC2 - Other",
            "vol-0689axxxxxxx"
          ],
          "Metrics": {
            "UnblendedCost": {
              "Amount": "0.0367741944",
              "Unit": "USD"
            }
          }
        },
        {
          "Keys": [
            "EC2 - Other",
            "vol-0dxxxxxx572"
          ],
          "Metrics": {
            "UnblendedCost": {
              "Amount": "0.0367741944",
              "Unit": "USD"
            }
          }
        },
        {
          "Keys": [
            "Amazon Elastic Compute Cloud - Compute",
            "i-02xxxxxdec4"
          ],
          "Metrics": {
            "UnblendedCost": {
              "Amount": "0.6912",
              "Unit": "USD"
            }
          }
        },
        {
          "Keys": [
            "Amazon Elastic Compute Cloud - Compute",
            "i-xxxxxxxxxe3"
          ],
          "Metrics": {
            "UnblendedCost": {
              "Amount": "1.248",
              "Unit": "USD"
            }
          }
        },
        {
          "Keys": [
            "Amazon Virtual Private Cloud",
            "arn:aws:ec2:ap-northeast-2:05xxxxxxxx3:network-interface/eni-0xxxxe34"
          ],
          "Metrics": {
            "UnblendedCost": {
              "Amount": "0.12",
              "Unit": "USD"
            }
          }
        }
      ],
      "TimePeriod": {
        "End": "2024-08-15T00:00:00Z",
        "Start": "2024-08-14T00:00:00Z"
      },
      "Total": {}
    }
  ]
}
```

