### PR TITLE
Include tag information when get VPC

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/VPCHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/VPCHandler.go
@@ -149,6 +149,17 @@ func ExtractVpcDescribeInfo(vpcInfo *vpc.Vpc) irs.VPCInfo {
 		IPv4_CIDR: *vpcInfo.CidrBlock,
 	}
 
+	if vpcInfo.TagSet != nil {
+		var tagList []irs.KeyValue
+		for _, tag := range vpcInfo.TagSet {
+			tagList = append(tagList, irs.KeyValue{
+				Key:   *tag.Key,
+				Value: *tag.Value,
+			})
+		}
+		resVpcInfo.TagList = tagList
+	}
+
 	return resVpcInfo
 }
 
@@ -360,6 +371,17 @@ func (VPCHandler *TencentVPCHandler) ListSubnet(reqVpcId string) ([]irs.SubnetIn
 			IId:       irs.IID{SystemId: *curSubnet.SubnetId, NameId: *curSubnet.SubnetName},
 			IPv4_CIDR: *curSubnet.CidrBlock,
 			//Status:    *subnetInfo.State,
+		}
+
+		if curSubnet.TagSet != nil {
+			var tagList []irs.KeyValue
+			for _, tag := range curSubnet.TagSet {
+				tagList = append(tagList, irs.KeyValue{
+					Key:   *tag.Key,
+					Value: *tag.Value,
+				})
+			}
+			resSubnetInfo.TagList = tagList
 		}
 
 		keyValueList := []irs.KeyValue{


### PR DESCRIPTION
- Tencent VPC 조회 시 Tag 정보 누락
- getVPC에서 vpc, subnet 정보 추출할 때 tag정보 추가하도록 수정


- 관련 이슈
 - https://github.com/cloud-barista/cb-spider/issues/1295