### PR TITLE
[AWS, GCP, ALIBABA, TENCENT] set KeyValueList for Resources

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/ClusterHandler.go
@@ -21,7 +21,6 @@ import (
 	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
 	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
-	"github.com/jeremywohl/flatten"
 	"gopkg.in/yaml.v2"
 
 	cs2015 "github.com/alibabacloud-go/cs-20151215/v4/client"
@@ -789,33 +788,35 @@ func (ach *AlibabaClusterHandler) getClusterInfoWithoutNodeGroupList(regionId, c
 	}
 
 	//
+	// 2025-03-13 StructToKeyValueList 사용으로 변경
+	clusterInfo.KeyValueList = irs.StructToKeyValueList(cluster)
 	// Fill clusterInfo.KeyValueList
 	//
-	jsonCluster, err := json.Marshal(cluster)
-	if err != nil {
-		err = fmt.Errorf("failed to marshal cluster: %v", err)
-		err = fmt.Errorf("failed to get ClusterInfo: %v", err)
-		return nil, err
-	}
+	// jsonCluster, err := json.Marshal(cluster)
+	// if err != nil {
+	// 	err = fmt.Errorf("failed to marshal cluster: %v", err)
+	// 	err = fmt.Errorf("failed to get ClusterInfo: %v", err)
+	// 	return nil, err
+	// }
 
-	var mapCluster map[string]interface{}
-	err = json.Unmarshal(jsonCluster, &mapCluster)
-	if err != nil {
-		err = fmt.Errorf("failed to unmarshal cluster: %v", err)
-		err = fmt.Errorf("failed to get ClusterInfo: %v", err)
-		return nil, err
-	}
+	// var mapCluster map[string]interface{}
+	// err = json.Unmarshal(jsonCluster, &mapCluster)
+	// if err != nil {
+	// 	err = fmt.Errorf("failed to unmarshal cluster: %v", err)
+	// 	err = fmt.Errorf("failed to get ClusterInfo: %v", err)
+	// 	return nil, err
+	// }
 
-	flat, err := flatten.Flatten(mapCluster, "", flatten.DotStyle)
-	if err != nil {
-		err = fmt.Errorf("failed to flatten cluster: %v", err)
-		err = fmt.Errorf("failed to get ClusterInfo: %v", err)
-		return nil, err
-	}
-	delete(flat, "meta_data")
-	for k, v := range flat {
-		clusterInfo.KeyValueList = append(clusterInfo.KeyValueList, irs.KeyValue{Key: k, Value: fmt.Sprintf("%v", v)})
-	}
+	// flat, err := flatten.Flatten(mapCluster, "", flatten.DotStyle)
+	// if err != nil {
+	// 	err = fmt.Errorf("failed to flatten cluster: %v", err)
+	// 	err = fmt.Errorf("failed to get ClusterInfo: %v", err)
+	// 	return nil, err
+	// }
+	// delete(flat, "meta_data")
+	// for k, v := range flat {
+	// 	clusterInfo.KeyValueList = append(clusterInfo.KeyValueList, irs.KeyValue{Key: k, Value: fmt.Sprintf("%v", v)})
+	// }
 
 	return clusterInfo, nil
 }
@@ -933,33 +934,35 @@ func (ach *AlibabaClusterHandler) getNodeGroupInfo(clusterId, nodeGroupId string
 	}
 
 	//
+	// 2025-03-13 StructToKeyValueList 사용으로 변경
+	nodeGroupInfo.KeyValueList = irs.StructToKeyValueList(nodepool)
 	// Fill nodeGroupInfo.KeyValueList
 	//
-	jsonNodepool, err := json.Marshal(nodepool)
-	if err != nil {
-		err = fmt.Errorf("failed to marshal nodepool: %v", err)
-		err = fmt.Errorf("failed to get NodeGroupInfo: %v", err)
-		return nil, err
-	}
+	// jsonNodepool, err := json.Marshal(nodepool)
+	// if err != nil {
+	// 	err = fmt.Errorf("failed to marshal nodepool: %v", err)
+	// 	err = fmt.Errorf("failed to get NodeGroupInfo: %v", err)
+	// 	return nil, err
+	// }
 
-	var mapNodepool map[string]interface{}
-	err = json.Unmarshal(jsonNodepool, &mapNodepool)
-	if err != nil {
-		err = fmt.Errorf("failed to unmarshal nodepool: %v", err)
-		err = fmt.Errorf("failed to get NodeGroupInfo: %v", err)
-		return nil, err
-	}
+	// var mapNodepool map[string]interface{}
+	// err = json.Unmarshal(jsonNodepool, &mapNodepool)
+	// if err != nil {
+	// 	err = fmt.Errorf("failed to unmarshal nodepool: %v", err)
+	// 	err = fmt.Errorf("failed to get NodeGroupInfo: %v", err)
+	// 	return nil, err
+	// }
 
-	flat, err := flatten.Flatten(mapNodepool, "", flatten.DotStyle)
-	if err != nil {
-		err = fmt.Errorf("failed to flatten nodepool: %v", err)
-		err = fmt.Errorf("failed to get NodeGroupInfo: %v", err)
-		return nil, err
-	}
-	delete(flat, "meta_data")
-	for k, v := range flat {
-		nodeGroupInfo.KeyValueList = append(nodeGroupInfo.KeyValueList, irs.KeyValue{Key: k, Value: fmt.Sprintf("%v", v)})
-	}
+	// flat, err := flatten.Flatten(mapNodepool, "", flatten.DotStyle)
+	// if err != nil {
+	// 	err = fmt.Errorf("failed to flatten nodepool: %v", err)
+	// 	err = fmt.Errorf("failed to get NodeGroupInfo: %v", err)
+	// 	return nil, err
+	// }
+	// delete(flat, "meta_data")
+	// for k, v := range flat {
+	// 	nodeGroupInfo.KeyValueList = append(nodeGroupInfo.KeyValueList, irs.KeyValue{Key: k, Value: fmt.Sprintf("%v", v)})
+	// }
 
 	return nodeGroupInfo, err
 }

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/DiskHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/DiskHandler.go
@@ -682,7 +682,7 @@ func ExtractDiskDescribeInfo(aliDisk *ecs.Disk) (irs.DiskInfo, error) {
 	diskInfo.Status = diskStatus
 
 	// 2025-03-13 StructToKeyValueList 사용으로 변경
-	diskInfo.KeyValueList = irs.StructToKeyValueList(&aliDisk)
+	diskInfo.KeyValueList = irs.StructToKeyValueList(aliDisk)
 	// keyValueList := []irs.KeyValue{
 	// 	{Key: "CreationTime", Value: aliDisk.CreationTime},
 	// 	{Key: "AttachedTime", Value: aliDisk.AttachedTime},

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/DiskHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/DiskHandler.go
@@ -681,58 +681,60 @@ func ExtractDiskDescribeInfo(aliDisk *ecs.Disk) (irs.DiskInfo, error) {
 	}
 	diskInfo.Status = diskStatus
 
-	keyValueList := []irs.KeyValue{
-		{Key: "CreationTime", Value: aliDisk.CreationTime},
-		{Key: "AttachedTime", Value: aliDisk.AttachedTime},
-		{Key: "DetachedTime", Value: aliDisk.DetachedTime},
-		{Key: "ExpiredTime", Value: aliDisk.ExpiredTime},
+	// 2025-03-13 StructToKeyValueList 사용으로 변경
+	diskInfo.KeyValueList = irs.StructToKeyValueList(&aliDisk)
+	// keyValueList := []irs.KeyValue{
+	// 	{Key: "CreationTime", Value: aliDisk.CreationTime},
+	// 	{Key: "AttachedTime", Value: aliDisk.AttachedTime},
+	// 	{Key: "DetachedTime", Value: aliDisk.DetachedTime},
+	// 	{Key: "ExpiredTime", Value: aliDisk.ExpiredTime},
 
-		{Key: "SerialNumber", Value: aliDisk.SerialNumber},
-		{Key: "Status", Value: aliDisk.Status}, // In_use, Available, Attaching, Detaching, Creating, ReIniting
-		{Key: "Size", Value: strconv.Itoa(aliDisk.Size)},
-		{Key: "Category", Value: aliDisk.Category},
-		{Key: "Type", Value: aliDisk.Type},                         // system, data
-		{Key: "PerformanceLevel", Value: aliDisk.PerformanceLevel}, // PL0, PL1, PL2, PL3
-		{Key: "BdfId", Value: aliDisk.BdfId},
-		{Key: "EnableAutoSnapshot", Value: strconv.FormatBool(aliDisk.EnableAutoSnapshot)},
-		{Key: "StorageSetId", Value: aliDisk.StorageSetId},
-		{Key: "StorageSetPartitionNumber", Value: strconv.Itoa(aliDisk.StorageSetPartitionNumber)},
+	// 	{Key: "SerialNumber", Value: aliDisk.SerialNumber},
+	// 	{Key: "Status", Value: aliDisk.Status}, // In_use, Available, Attaching, Detaching, Creating, ReIniting
+	// 	{Key: "Size", Value: strconv.Itoa(aliDisk.Size)},
+	// 	{Key: "Category", Value: aliDisk.Category},
+	// 	{Key: "Type", Value: aliDisk.Type},                         // system, data
+	// 	{Key: "PerformanceLevel", Value: aliDisk.PerformanceLevel}, // PL0, PL1, PL2, PL3
+	// 	{Key: "BdfId", Value: aliDisk.BdfId},
+	// 	{Key: "EnableAutoSnapshot", Value: strconv.FormatBool(aliDisk.EnableAutoSnapshot)},
+	// 	{Key: "StorageSetId", Value: aliDisk.StorageSetId},
+	// 	{Key: "StorageSetPartitionNumber", Value: strconv.Itoa(aliDisk.StorageSetPartitionNumber)},
 
-		{Key: "aliDiskId", Value: aliDisk.DiskId},
-		{Key: "DeleteAutoSnapshot", Value: strconv.FormatBool(aliDisk.DeleteAutoSnapshot)},
-		{Key: "Encrypted", Value: strconv.FormatBool(aliDisk.Encrypted)},
-		{Key: "IOPS", Value: strconv.Itoa(aliDisk.IOPS)},
-		{Key: "IOPSRead", Value: strconv.Itoa(aliDisk.IOPSRead)},
-		{Key: "IOPSWrite", Value: strconv.Itoa(aliDisk.IOPSWrite)},
-		{Key: "Throughput", Value: strconv.Itoa(aliDisk.Throughput)},
-		{Key: "MountInstanceNum", Value: strconv.Itoa(aliDisk.MountInstanceNum)},
+	// 	{Key: "aliDiskId", Value: aliDisk.DiskId},
+	// 	{Key: "DeleteAutoSnapshot", Value: strconv.FormatBool(aliDisk.DeleteAutoSnapshot)},
+	// 	{Key: "Encrypted", Value: strconv.FormatBool(aliDisk.Encrypted)},
+	// 	{Key: "IOPS", Value: strconv.Itoa(aliDisk.IOPS)},
+	// 	{Key: "IOPSRead", Value: strconv.Itoa(aliDisk.IOPSRead)},
+	// 	{Key: "IOPSWrite", Value: strconv.Itoa(aliDisk.IOPSWrite)},
+	// 	{Key: "Throughput", Value: strconv.Itoa(aliDisk.Throughput)},
+	// 	{Key: "MountInstanceNum", Value: strconv.Itoa(aliDisk.MountInstanceNum)},
 
-		{Key: "Description", Value: aliDisk.Description},
-		{Key: "Device", Value: aliDisk.Device},
-		{Key: "aliDiskName", Value: aliDisk.DiskName},
-		{Key: "Portable", Value: strconv.FormatBool(aliDisk.Portable)},
-		{Key: "ImageId", Value: aliDisk.ImageId},
-		{Key: "KMSKeyId", Value: aliDisk.KMSKeyId},
+	// 	{Key: "Description", Value: aliDisk.Description},
+	// 	{Key: "Device", Value: aliDisk.Device},
+	// 	{Key: "aliDiskName", Value: aliDisk.DiskName},
+	// 	{Key: "Portable", Value: strconv.FormatBool(aliDisk.Portable)},
+	// 	{Key: "ImageId", Value: aliDisk.ImageId},
+	// 	{Key: "KMSKeyId", Value: aliDisk.KMSKeyId},
 
-		{Key: "DeleteWithInstance", Value: strconv.FormatBool(aliDisk.DeleteWithInstance)},
+	// 	{Key: "DeleteWithInstance", Value: strconv.FormatBool(aliDisk.DeleteWithInstance)},
 
-		{Key: "SourceSnapshotId", Value: aliDisk.SourceSnapshotId},
-		{Key: "AutoSnapshotPolicyId", Value: aliDisk.AutoSnapshotPolicyId},
-		{Key: "EnableAutomatedSnapshotPolicy", Value: strconv.FormatBool(aliDisk.EnableAutomatedSnapshotPolicy)},
-		{Key: "InstanceId", Value: aliDisk.InstanceId},
-		{Key: "RegionId", Value: aliDisk.RegionId},
-		{Key: "ZoneId", Value: aliDisk.ZoneId},
+	// 	{Key: "SourceSnapshotId", Value: aliDisk.SourceSnapshotId},
+	// 	{Key: "AutoSnapshotPolicyId", Value: aliDisk.AutoSnapshotPolicyId},
+	// 	{Key: "EnableAutomatedSnapshotPolicy", Value: strconv.FormatBool(aliDisk.EnableAutomatedSnapshotPolicy)},
+	// 	{Key: "InstanceId", Value: aliDisk.InstanceId},
+	// 	{Key: "RegionId", Value: aliDisk.RegionId},
+	// 	{Key: "ZoneId", Value: aliDisk.ZoneId},
 
-		{Key: "aliDiskChargeType", Value: aliDisk.DiskChargeType},
-		{Key: "ResourceGroupId", Value: aliDisk.ResourceGroupId},
-		{Key: "ProductCode", Value: aliDisk.ProductCode},
-		{Key: "MultiAttach", Value: aliDisk.MultiAttach},
+	// 	{Key: "aliDiskChargeType", Value: aliDisk.DiskChargeType},
+	// 	{Key: "ResourceGroupId", Value: aliDisk.ResourceGroupId},
+	// 	{Key: "ProductCode", Value: aliDisk.ProductCode},
+	// 	{Key: "MultiAttach", Value: aliDisk.MultiAttach},
 
-		{Key: "ResourceGroupId", Value: aliDisk.ResourceGroupId},
-	}
+	// 	{Key: "ResourceGroupId", Value: aliDisk.ResourceGroupId},
+	// }
 
-	//keyValueList = append(keyValueList, irs.KeyValue{Key: "Description", Value: disk.Description})
-	diskInfo.KeyValueList = keyValueList
+	// //keyValueList = append(keyValueList, irs.KeyValue{Key: "Description", Value: disk.Description})
+	// diskInfo.KeyValueList = keyValueList
 	return diskInfo, nil
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/KeyPairHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/KeyPairHandler.go
@@ -276,7 +276,6 @@ func ExtractKeyPairDescribeInfo(keyPair *ecs.KeyPair) (irs.KeyPairInfo, error) {
 	}
 
 	tagList := []irs.KeyValue{}
-	cblogger.Info("eeeeeeeeeee", keyPair.Tags)
 	for _, aliTag := range keyPair.Tags.Tag {
 		kTag := irs.KeyValue{}
 		kTag.Key = aliTag.TagKey
@@ -319,7 +318,7 @@ func ExtractKeyPairDescribeInfo(keyPair *ecs.KeyPair) (irs.KeyPairInfo, error) {
 	// }
 	// keyPairInfo.KeyValueList = keyValueList
 	// 2025-03-13 keyvalueList를 StructToKeyValueList로 set
-	keyPairInfo.KeyValueList = irs.StructToKeyValueList(&keyPair)
+	keyPairInfo.KeyValueList = irs.StructToKeyValueList(keyPair)
 
 	return keyPairInfo, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/KeyPairHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/KeyPairHandler.go
@@ -168,15 +168,18 @@ func (keyPairHandler *AlibabaKeyPairHandler) CreateKey(keyPairReqInfo irs.KeyPai
 	cblogger.Infof("Public Key")
 	cblogger.Debug(publicKey)
 	*/
-	keyPairInfo := irs.KeyPairInfo{
-		IId:         irs.IID{NameId: result.KeyPairName, SystemId: result.KeyPairName},
-		Fingerprint: result.KeyPairFingerPrint,
-		PrivateKey:  result.PrivateKeyBody,
-		//PublicKey:   publicKey,
-		KeyValueList: []irs.KeyValue{
-			{Key: "KeyMaterial", Value: result.PrivateKeyBody},
-		},
-	}
+	// keyPairInfo := irs.KeyPairInfo{
+	// 	IId:         irs.IID{NameId: result.KeyPairName, SystemId: result.KeyPairName},
+	// 	Fingerprint: result.KeyPairFingerPrint,
+	// 	PrivateKey:  result.PrivateKeyBody,
+	// 	//PublicKey:   publicKey,
+	// 	KeyValueList: []irs.KeyValue{
+	// 		{Key: "KeyMaterial", Value: result.PrivateKeyBody},
+	// 	},
+	// }
+
+	// keyPairInfo 를 직접  set에서 GetKey로 변경
+	keyPairInfo, err := keyPairHandler.GetKey(irs.IID{NameId: keyPairReqInfo.IId.NameId, SystemId: result.KeyPairName})
 
 	/* 2021-10-27 이슈#480에 의해 Local Key 로직 제거
 	hashString := strings.ReplaceAll(keyPairInfo.Fingerprint, ":", "") // 필요한 경우 리전 정보 추가하면 될 듯. 나중에 키 이름과 리전으로 암복호화를 진행하면 될 것같음.
@@ -310,12 +313,13 @@ func ExtractKeyPairDescribeInfo(keyPair *ecs.KeyPair) (irs.KeyPairInfo, error) {
 	keyPairInfo.PublicKey = string(publicKeyBytes)
 	keyPairInfo.PrivateKey = string(privateKeyBytes)
 	*/
-	keyValueList := []irs.KeyValue{
-		//{Key: "ResourceGroupId", Value: keyPair.ResourceGroupId},
-		{Key: "CreationTime", Value: keyPair.CreationTime},
-	}
-
-	keyPairInfo.KeyValueList = keyValueList
+	// keyValueList := []irs.KeyValue{
+	// 	//{Key: "ResourceGroupId", Value: keyPair.ResourceGroupId},
+	// 	{Key: "CreationTime", Value: keyPair.CreationTime},
+	// }
+	// keyPairInfo.KeyValueList = keyValueList
+	// 2025-03-13 keyvalueList를 StructToKeyValueList로 set
+	keyPairInfo.KeyValueList = irs.StructToKeyValueList(&keyPair)
 
 	return keyPairInfo, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/MyImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/MyImageHandler.go
@@ -5,7 +5,6 @@ package resources
 import (
 	"errors"
 	"reflect"
-	"strconv"
 	"strings"
 	"time"
 
@@ -314,25 +313,28 @@ func ExtractMyImageDescribeInfo(aliMyImage *ecs.Image) (irs.MyImageInfo, error) 
 		aliMyImage.CreationTime) // RFC3339형태이므로 해당 시간으로 다시 생성
 	returnMyImageInfo.CreatedTime = createdTime
 
+	// 2025-03-13 StructToKeyValueList 사용으로 변경
 	keyValueList := []irs.KeyValue{}
-	keyValueList = append(keyValueList, irs.KeyValue{Key: "ImageOwnerAlias", Value: aliMyImage.ImageOwnerAlias})
-	keyValueList = append(keyValueList, irs.KeyValue{Key: "IsSelfShared", Value: aliMyImage.IsSelfShared})
-	keyValueList = append(keyValueList, irs.KeyValue{Key: "Description", Value: aliMyImage.Description})
-	keyValueList = append(keyValueList, irs.KeyValue{Key: "Platform", Value: aliMyImage.Platform})
-	keyValueList = append(keyValueList, irs.KeyValue{Key: "ResourceGroupId", Value: aliMyImage.ResourceGroupId})
-	keyValueList = append(keyValueList, irs.KeyValue{Key: "Size", Value: strconv.Itoa(aliMyImage.Size)})
-	keyValueList = append(keyValueList, irs.KeyValue{Key: "IsSubscribed", Value: strconv.FormatBool(aliMyImage.IsSubscribed)})
-	//keyValueList = append(keyValueList, irs.KeyValue{Key: "architecture", Value: strconv.FormatBool(aliMyImage.)})
-	keyValueList = append(keyValueList, irs.KeyValue{Key: "OSName", Value: aliMyImage.OSName})
-	keyValueList = append(keyValueList, irs.KeyValue{Key: "OSNameEn", Value: aliMyImage.OSNameEn})
+	keyValueList = irs.StructToKeyValueList(&aliMyImage)
+	// keyValueList := []irs.KeyValue{}
+	// keyValueList = append(keyValueList, irs.KeyValue{Key: "ImageOwnerAlias", Value: aliMyImage.ImageOwnerAlias})
+	// keyValueList = append(keyValueList, irs.KeyValue{Key: "IsSelfShared", Value: aliMyImage.IsSelfShared})
+	// keyValueList = append(keyValueList, irs.KeyValue{Key: "Description", Value: aliMyImage.Description})
+	// keyValueList = append(keyValueList, irs.KeyValue{Key: "Platform", Value: aliMyImage.Platform})
+	// keyValueList = append(keyValueList, irs.KeyValue{Key: "ResourceGroupId", Value: aliMyImage.ResourceGroupId})
+	// keyValueList = append(keyValueList, irs.KeyValue{Key: "Size", Value: strconv.Itoa(aliMyImage.Size)})
+	// keyValueList = append(keyValueList, irs.KeyValue{Key: "IsSubscribed", Value: strconv.FormatBool(aliMyImage.IsSubscribed)})
+	// //keyValueList = append(keyValueList, irs.KeyValue{Key: "architecture", Value: strconv.FormatBool(aliMyImage.)})
+	// keyValueList = append(keyValueList, irs.KeyValue{Key: "OSName", Value: aliMyImage.OSName})
+	// keyValueList = append(keyValueList, irs.KeyValue{Key: "OSNameEn", Value: aliMyImage.OSNameEn})
 
-	keyValueList = append(keyValueList, irs.KeyValue{Key: "Progress", Value: aliMyImage.Progress})
-	keyValueList = append(keyValueList, irs.KeyValue{Key: "Usage", Value: aliMyImage.Usage})
-	keyValueList = append(keyValueList, irs.KeyValue{Key: "Architecture", Value: aliMyImage.Architecture})
-	keyValueList = append(keyValueList, irs.KeyValue{Key: "IsCopied", Value: strconv.FormatBool(aliMyImage.IsCopied)})
-	keyValueList = append(keyValueList, irs.KeyValue{Key: "IsSupportCloudinit", Value: strconv.FormatBool(aliMyImage.IsSupportCloudinit)})
-	keyValueList = append(keyValueList, irs.KeyValue{Key: "ImageVersion", Value: aliMyImage.ImageVersion})
-	keyValueList = append(keyValueList, irs.KeyValue{Key: "OSType", Value: aliMyImage.OSType})
+	// keyValueList = append(keyValueList, irs.KeyValue{Key: "Progress", Value: aliMyImage.Progress})
+	// keyValueList = append(keyValueList, irs.KeyValue{Key: "Usage", Value: aliMyImage.Usage})
+	// keyValueList = append(keyValueList, irs.KeyValue{Key: "Architecture", Value: aliMyImage.Architecture})
+	// keyValueList = append(keyValueList, irs.KeyValue{Key: "IsCopied", Value: strconv.FormatBool(aliMyImage.IsCopied)})
+	// keyValueList = append(keyValueList, irs.KeyValue{Key: "IsSupportCloudinit", Value: strconv.FormatBool(aliMyImage.IsSupportCloudinit)})
+	// keyValueList = append(keyValueList, irs.KeyValue{Key: "ImageVersion", Value: aliMyImage.ImageVersion})
+	// keyValueList = append(keyValueList, irs.KeyValue{Key: "OSType", Value: aliMyImage.OSType})
 
 	returnMyImageInfo.KeyValueList = keyValueList
 

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/MyImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/MyImageHandler.go
@@ -315,7 +315,7 @@ func ExtractMyImageDescribeInfo(aliMyImage *ecs.Image) (irs.MyImageInfo, error) 
 
 	// 2025-03-13 StructToKeyValueList 사용으로 변경
 	keyValueList := []irs.KeyValue{}
-	keyValueList = irs.StructToKeyValueList(&aliMyImage)
+	keyValueList = irs.StructToKeyValueList(aliMyImage)
 	// keyValueList := []irs.KeyValue{}
 	// keyValueList = append(keyValueList, irs.KeyValue{Key: "ImageOwnerAlias", Value: aliMyImage.ImageOwnerAlias})
 	// keyValueList = append(keyValueList, irs.KeyValue{Key: "IsSelfShared", Value: aliMyImage.IsSelfShared})

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/NLBHandler.go
@@ -246,6 +246,7 @@ func (NLBHandler *AlibabaNLBHandler) GetNLB(nlbIID irs.IID) (irs.NLBInfo, error)
 	var nlbInfo irs.NLBInfo
 	vmGroup := irs.VMGroupInfo{}
 	healthChecker := irs.HealthCheckerInfo{}
+	keyvalueList := []irs.KeyValue{}
 
 	request := slb.CreateDescribeLoadBalancerAttributeRequest()
 	request.LoadBalancerId = nlbIID.SystemId
@@ -324,10 +325,11 @@ func (NLBHandler *AlibabaNLBHandler) GetNLB(nlbIID irs.IID) (irs.NLBInfo, error)
 		if err != nil {
 			cblogger.Error(err.Error())
 			// vm 정보 조회 실패
-			var inKeyValueList []irs.KeyValue
-			keyValue := irs.KeyValue{"reason", err.Error()}
-			inKeyValueList = append(inKeyValueList, keyValue)
-			vmGroup.KeyValueList = inKeyValueList
+			// var inKeyValueList []irs.KeyValue
+			// keyValue := irs.KeyValue{"reason", err.Error()}
+			// inKeyValueList = append(inKeyValueList, keyValue)
+			// vmGroup.KeyValueList = inKeyValueList
+			vmGroup.KeyValueList = irs.StructToKeyValueList(err)
 		} else {
 			vmIID = vmInfo.IId
 			nlbInfo.VpcIID = vmInfo.VpcIID
@@ -355,7 +357,7 @@ func (NLBHandler *AlibabaNLBHandler) GetNLB(nlbIID irs.IID) (irs.NLBInfo, error)
 		time.RFC3339,
 		lbAttributeResponse.CreateTime) // RFC3339형태이므로 해당 시간으로 다시 생성. "CreateTime": "2022-07-05T07:54:37Z",
 	nlbInfo.CreatedTime = createdTime
-
+	nlbInfo.KeyValueList = irs.StructToKeyValueList(&lbAttributeResponse)
 	return nlbInfo, nil
 }
 
@@ -1338,6 +1340,8 @@ func (NLBHandler *AlibabaNLBHandler) describeLoadBalancerTcpListenerAttribute(nl
 	//nlbInfo.Listener = listener// listener자체는 변경안됨( protocol, port 변경 불가함.)
 	nlbInfo.VMGroup = vmGroup
 	nlbInfo.HealthChecker = healthChecker
+	// 2025-03-13 StructToKeyValueList 사용으로 변경
+	nlbInfo.KeyValueList = irs.StructToKeyValueList(&listenerAttributeResponse)
 	return nlbInfo, nil
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/NLBHandler.go
@@ -357,7 +357,7 @@ func (NLBHandler *AlibabaNLBHandler) GetNLB(nlbIID irs.IID) (irs.NLBInfo, error)
 		time.RFC3339,
 		lbAttributeResponse.CreateTime) // RFC3339형태이므로 해당 시간으로 다시 생성. "CreateTime": "2022-07-05T07:54:37Z",
 	nlbInfo.CreatedTime = createdTime
-	nlbInfo.KeyValueList = irs.StructToKeyValueList(&lbAttributeResponse)
+	nlbInfo.KeyValueList = irs.StructToKeyValueList(lbAttributeResponse)
 	return nlbInfo, nil
 }
 
@@ -1341,7 +1341,7 @@ func (NLBHandler *AlibabaNLBHandler) describeLoadBalancerTcpListenerAttribute(nl
 	nlbInfo.VMGroup = vmGroup
 	nlbInfo.HealthChecker = healthChecker
 	// 2025-03-13 StructToKeyValueList 사용으로 변경
-	nlbInfo.KeyValueList = irs.StructToKeyValueList(&listenerAttributeResponse)
+	nlbInfo.KeyValueList = irs.StructToKeyValueList(listenerAttributeResponse)
 	return nlbInfo, nil
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/NLBHandler.go
@@ -280,6 +280,7 @@ func (NLBHandler *AlibabaNLBHandler) GetNLB(nlbIID irs.IID) (irs.NLBInfo, error)
 		//DNSName		string	// Optional, Auto Generated and attached
 		listener.CspID = lbAttributeResponse.ResourceGroupId
 		//KeyValueList []KeyValue
+		//listener.KeyValueList = irs.StructToKeyValueList(listenerProtocolAndPort) // nlbInfo의 keyvalue에 있는 내용이므로 추가하지 않음
 		break
 	}
 	nlbInfo.Listener = listener
@@ -305,6 +306,7 @@ func (NLBHandler *AlibabaNLBHandler) GetNLB(nlbIID irs.IID) (irs.NLBInfo, error)
 
 		vmGroup = responseNlbInfo.VMGroup
 		healthChecker = responseNlbInfo.HealthChecker
+		healthChecker.KeyValueList = irs.StructToKeyValueList(responseNlbInfo)
 	} else if strings.EqualFold(listener.Protocol, ListenerProtocol_UDP) {
 		responseNlbInfo, err := NLBHandler.describeLoadBalancerUdpListenerAttribute(nlbIID, listener)
 		if err != nil {
@@ -313,6 +315,7 @@ func (NLBHandler *AlibabaNLBHandler) GetNLB(nlbIID irs.IID) (irs.NLBInfo, error)
 
 		vmGroup = responseNlbInfo.VMGroup
 		healthChecker = responseNlbInfo.HealthChecker
+		healthChecker.KeyValueList = irs.StructToKeyValueList(responseNlbInfo)
 	}
 
 	var vms []irs.IID

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/NLBHandler.go
@@ -246,7 +246,7 @@ func (NLBHandler *AlibabaNLBHandler) GetNLB(nlbIID irs.IID) (irs.NLBInfo, error)
 	var nlbInfo irs.NLBInfo
 	vmGroup := irs.VMGroupInfo{}
 	healthChecker := irs.HealthCheckerInfo{}
-	keyvalueList := []irs.KeyValue{}
+	//keyvalueList := []irs.KeyValue{}
 
 	request := slb.CreateDescribeLoadBalancerAttributeRequest()
 	request.LoadBalancerId = nlbIID.SystemId

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/SecurityHandler.go
@@ -458,7 +458,7 @@ func (securityHandler *AlibabaSecurityHandler) ExtractSecurityInfo(securityGroup
 		}
 		securityInfo.TagList = tagList
 	}
-	securityInfo.KeyValueList = irs.StructToKeyValueList(&securityGroupResult)
+	securityInfo.KeyValueList = irs.StructToKeyValueList(securityGroupResult)
 	return securityInfo, nil
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/SecurityHandler.go
@@ -443,10 +443,10 @@ func (securityHandler *AlibabaSecurityHandler) ExtractSecurityInfo(securityGroup
 		VpcIID:        irs.IID{SystemId: securityGroupResult.VpcId},
 		SecurityRules: &securityRuleInfos,
 
-		KeyValueList: []irs.KeyValue{
-			{Key: "SecurityGroupName", Value: securityGroupResult.SecurityGroupName},
-			{Key: "CreationTime", Value: securityGroupResult.CreationTime},
-		},
+		// KeyValueList: []irs.KeyValue{
+		// 	{Key: "SecurityGroupName", Value: securityGroupResult.SecurityGroupName},
+		// 	{Key: "CreationTime", Value: securityGroupResult.CreationTime},
+		// },
 	}
 	if securityGroupResult.Tags.Tag != nil {
 		var tagList []irs.KeyValue
@@ -458,7 +458,7 @@ func (securityHandler *AlibabaSecurityHandler) ExtractSecurityInfo(securityGroup
 		}
 		securityInfo.TagList = tagList
 	}
-
+	securityInfo.KeyValueList = irs.StructToKeyValueList(&securityGroupResult)
 	return securityInfo, nil
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/VMHandler.go
@@ -989,7 +989,7 @@ func (vmHandler *AlibabaVMHandler) ExtractDescribeInstances(instanceInfo *ecs.In
 			vmInfo.StartTime = t
 		}
 	}
-
+	vmInfo.KeyValueList = irs.StructToKeyValueList(instanceInfo)
 	return vmInfo, nil
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/VPCHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/VPCHandler.go
@@ -271,7 +271,7 @@ func ExtractVpcDescribeInfo(vpcInfo *vpc.Vpc) irs.VPCInfo {
 	aliVpcInfo.TagList = tagList
 
 	// 2025-03-13 StructToKeyValueList 사용으로 변경
-	aliVpcInfo.KeyValueList = irs.StructToKeyValueList(&vpcInfo)
+	aliVpcInfo.KeyValueList = irs.StructToKeyValueList(vpcInfo)
 	// keyValueList := []irs.KeyValue{
 	// 	{Key: "IsDefault", Value: strconv.FormatBool(vpcInfo.IsDefault)},
 	// 	{Key: "Status", Value: vpcInfo.Status},

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/VPCHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/VPCHandler.go
@@ -14,7 +14,6 @@ package resources
 
 import (
 	"errors"
-	"strconv"
 	"strings"
 	"time"
 
@@ -271,13 +270,15 @@ func ExtractVpcDescribeInfo(vpcInfo *vpc.Vpc) irs.VPCInfo {
 	}
 	aliVpcInfo.TagList = tagList
 
-	keyValueList := []irs.KeyValue{
-		{Key: "IsDefault", Value: strconv.FormatBool(vpcInfo.IsDefault)},
-		{Key: "Status", Value: vpcInfo.Status},
-		{Key: "VRouterId", Value: vpcInfo.VRouterId},
-		{Key: "RegionId", Value: vpcInfo.RegionId},
-	}
-	aliVpcInfo.KeyValueList = keyValueList
+	// 2025-03-13 StructToKeyValueList 사용으로 변경
+	aliVpcInfo.KeyValueList = irs.StructToKeyValueList(&vpcInfo)
+	// keyValueList := []irs.KeyValue{
+	// 	{Key: "IsDefault", Value: strconv.FormatBool(vpcInfo.IsDefault)},
+	// 	{Key: "Status", Value: vpcInfo.Status},
+	// 	{Key: "VRouterId", Value: vpcInfo.VRouterId},
+	// 	{Key: "RegionId", Value: vpcInfo.RegionId},
+	// }
+	// aliVpcInfo.KeyValueList = keyValueList
 
 	return aliVpcInfo
 }
@@ -514,13 +515,14 @@ func ExtractSubnetDescribeInfo(subnetInfo vpc.VSwitch) irs.SubnetInfo {
 	vNetworkInfo.TagList = tagList
 
 	/////
-
-	keyValueList := []irs.KeyValue{
-		{Key: "Status", Value: subnetInfo.Status},
-		{Key: "IsDefault", Value: strconv.FormatBool(subnetInfo.IsDefault)},
-		{Key: "ZoneId", Value: subnetInfo.ZoneId},
-	}
-	vNetworkInfo.KeyValueList = keyValueList
+	// 2025-03-13 StructToKeyValueList 사용으로 변경
+	vNetworkInfo.KeyValueList = irs.StructToKeyValueList(subnetInfo)
+	// keyValueList := []irs.KeyValue{
+	// 	{Key: "Status", Value: subnetInfo.Status},
+	// 	{Key: "IsDefault", Value: strconv.FormatBool(subnetInfo.IsDefault)},
+	// 	{Key: "ZoneId", Value: subnetInfo.ZoneId},
+	// }
+	// vNetworkInfo.KeyValueList = keyValueList
 
 	return vNetworkInfo
 }

--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -2358,8 +2358,8 @@ func main() {
 	//handleCluster()
 	// handleImage() //AMI
 	// handleVNic() //Lancard
-	handleVMSpec()
+	//handleVMSpec()
 	//handleRegionZone()
-	//handlePriceInfo()
+	handlePriceInfo()
 	//handleTag()
 }

--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -2348,7 +2348,7 @@ func main() {
 	//handleTag()
 	// handlePublicIP() // PublicIP 생성 후 conf
 
-	//handleVPC()
+	handleVPC()
 	//handleSecurity()
 	//handleKeyPair()
 	//handleVM()
@@ -2360,6 +2360,6 @@ func main() {
 	// handleVNic() //Lancard
 	//handleVMSpec()
 	//handleRegionZone()
-	handlePriceInfo()
+	//handlePriceInfo()
 	//handleTag()
 }

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/DiskHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/DiskHandler.go
@@ -5,7 +5,6 @@ package resources
 import (
 	"errors"
 	"fmt"
-	"reflect"
 	"strconv"
 	"strings"
 
@@ -425,6 +424,7 @@ func (DiskHandler *AwsDiskHandler) AttachDisk(diskIID irs.IID, ownerVM irs.IID) 
 	}
 	return returnDiskInfo, nil
 }
+
 func (DiskHandler *AwsDiskHandler) DetachDisk(diskIID irs.IID, ownerVM irs.IID) (bool, error) {
 	hiscallInfo := GetCallLogScheme(DiskHandler.Region, call.DISK, diskIID.NameId, "DetachDisk()")
 	start := call.Start()
@@ -893,24 +893,28 @@ func (DiskHandler *AwsDiskHandler) convertVolumeInfoToDiskInfo(volumeInfo *ec2.V
 	}
 
 	diskInfo.CreatedTime = *volumeInfo.CreateTime
-	//KeyValueList []KeyValue
-	var inKeyValueList []irs.KeyValue
-	//if !reflect.ValueOf(volumeInfo.Encrypted).IsNil() {
-	inKeyValueList = append(inKeyValueList, irs.KeyValue{Key: "Encrypted", Value: strconv.FormatBool(*volumeInfo.Encrypted)})
-	//}
-	if !reflect.ValueOf(volumeInfo.Iops).IsNil() {
-		inKeyValueList = append(inKeyValueList, irs.KeyValue{Key: "Iops", Value: strconv.Itoa(int(*volumeInfo.Iops))})
-	}
-	//inKeyValueList = append(inKeyValueList, icbs.KeyValue{Key: "KmsKeyId", Value: *volumeInfo.KmsKeyId})
-	inKeyValueList = append(inKeyValueList, irs.KeyValue{Key: "MultiAttachEnabled", Value: strconv.FormatBool(*volumeInfo.MultiAttachEnabled)})
 
-	//inKeyValueList = append(inKeyValueList, icbs.KeyValue{Key: "Tags", Value: strings.Join(volumeInfo.Tags, ",")})
-	//inKeyValueList = append(inKeyValueList, icbs.KeyValue{Key: "OutpostArn", Value: *volumeInfo.OutpostArn})
-	diskInfo.KeyValueList = inKeyValueList
-	cblogger.Debug("keyvalue2")
-	cblogger.Debug(diskInfo)
+	// //KeyValueList []KeyValue
+	// var inKeyValueList []irs.KeyValue
+	// //if !reflect.ValueOf(volumeInfo.Encrypted).IsNil() {
+	// inKeyValueList = append(inKeyValueList, irs.KeyValue{Key: "Encrypted", Value: strconv.FormatBool(*volumeInfo.Encrypted)})
+	// //}
+	// if !reflect.ValueOf(volumeInfo.Iops).IsNil() {
+	// 	inKeyValueList = append(inKeyValueList, irs.KeyValue{Key: "Iops", Value: strconv.Itoa(int(*volumeInfo.Iops))})
+	// }
+	// //inKeyValueList = append(inKeyValueList, icbs.KeyValue{Key: "KmsKeyId", Value: *volumeInfo.KmsKeyId})
+	// inKeyValueList = append(inKeyValueList, irs.KeyValue{Key: "MultiAttachEnabled", Value: strconv.FormatBool(*volumeInfo.MultiAttachEnabled)})
+
+	// //inKeyValueList = append(inKeyValueList, icbs.KeyValue{Key: "Tags", Value: strings.Join(volumeInfo.Tags, ",")})
+	// //inKeyValueList = append(inKeyValueList, icbs.KeyValue{Key: "OutpostArn", Value: *volumeInfo.OutpostArn})
+	// diskInfo.KeyValueList = inKeyValueList
+	// cblogger.Debug("keyvalue2")
+
+	// Use irs.StructToKeyValueList to populate KeyValueList
+	diskInfo.KeyValueList = irs.StructToKeyValueList(volumeInfo)
 
 	diskInfo.TagList, _ = DiskHandler.TagHandler.ListTag(irs.DISK, diskInfo.IId)
+	cblogger.Debug(diskInfo)
 
 	return diskInfo, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/KeyPairHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/KeyPairHandler.go
@@ -179,10 +179,11 @@ func (keyPairHandler *AwsKeyPairHandler) CreateKey(keyPairReqInfo irs.KeyPairReq
 		PrivateKey:  *result.KeyMaterial, // AWS(PEM파일-RSA PRIVATE KEY)
 		//PublicKey:   publicKey,
 		//KeyMaterial: *result.KeyMaterial,
-		KeyValueList: []irs.KeyValue{
-			{Key: "KeyMaterial", Value: *result.KeyMaterial},
-		},
+		// KeyValueList: []irs.KeyValue{
+		// 	{Key: "KeyMaterial", Value: *result.KeyMaterial},
+		// },
 	}
+	keyPairInfo.KeyValueList = irs.StructToKeyValueList(result) // 공통 KeyValueList 추가
 
 	//cblogger.Debug(keyPairInfo)
 
@@ -342,11 +343,12 @@ func ExtractKeyPairDescribeInfo(keyPair *ec2.KeyPairInfo) (irs.KeyPairInfo, erro
 	keyPairInfo.PrivateKey = string(privateKeyBytes)
 	*/
 
-	keyValueList := []irs.KeyValue{
-		//{Key: "KeyMaterial", Value: *keyPair.KeyMaterial},
-	}
+	// keyValueList := []irs.KeyValue{
+	// 	//{Key: "KeyMaterial", Value: *keyPair.KeyMaterial},
+	// }
 
-	keyPairInfo.KeyValueList = keyValueList
+	// keyPairInfo.KeyValueList = keyValueList
+	keyPairInfo.KeyValueList = irs.StructToKeyValueList(keyPair) // KeyValueList 추가
 
 	return keyPairInfo, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/MyImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/MyImageHandler.go
@@ -551,6 +551,8 @@ func convertAWSImageToMyImageInfo(awsImage *ec2.Image) (irs.MyImageInfo, error) 
 	//usageOperation		The operation of the Amazon EC2 instance and the billing code that is associated with the AMI. usageOperation corresponds to the lineitem/Operation column on your AWS Cost and Usage Report and in the AWS Price List API. You can view these fields on the Instances or AMIs pages in the Amazon EC2 console, or in the responses that are returned by the DescribeImages command in the Amazon EC2 API, or the describe-images command in the AWS CLI.
 	//virtualizationType	The type of virtualization of the AMI.	Type: String	Valid Values: hvm | paravirtual
 
+	// Use irs.StructToKeyValueList to populate KeyValueList
+	returnMyImage.KeyValueList = irs.StructToKeyValueList(awsImage)
 	return returnMyImage, nil
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/NLBHandler.go
@@ -866,8 +866,11 @@ func (NLBHandler *AwsNLBHandler) ExtractListenerInfo(nlbIID irs.IID) (irs.Listen
 		retListenerInfo.Port = strconv.FormatInt(*resListener.Listeners[0].Port, 10)
 
 		//Key Value 처리
-		keyValueList, _ := ConvertKeyValueList(resListener.Listeners[0])
-		retListenerInfo.KeyValueList = keyValueList
+		// keyValueList, _ := ConvertKeyValueList(resListener.Listeners[0])
+		// retListenerInfo.KeyValueList = keyValueList
+
+		// Use irs.StructToKeyValueList to populate KeyValueList
+		retListenerInfo.KeyValueList = irs.StructToKeyValueList(resListener.Listeners[0])
 
 		return retListenerInfo, nil
 	} else {
@@ -930,8 +933,12 @@ func (NLBHandler *AwsNLBHandler) ExtractVMGroupInfo(nlbIID irs.IID) (TargetGroup
 		//================
 		//Key Value 처리
 		//================
-		keyValueList, _ := ConvertKeyValueList(result.TargetGroups[0])
-		targetGroupInfo.VMGroup.KeyValueList = keyValueList
+		// keyValueList, _ := ConvertKeyValueList(result.TargetGroups[0])
+		// targetGroupInfo.VMGroup.KeyValueList = keyValueList
+
+		// Use irs.StructToKeyValueList to populate KeyValueList
+		targetGroupInfo.VMGroup.KeyValueList = irs.StructToKeyValueList(result.TargetGroups[0])
+		targetGroupInfo.HealthChecker.KeyValueList = irs.StructToKeyValueList(result.TargetGroups[0])
 
 		//=========================
 		// 헬스 상태별 VM 목록 처리
@@ -1005,8 +1012,11 @@ func (NLBHandler *AwsNLBHandler) ExtractNLBInfo(nlbResInfo *elbv2.LoadBalancer) 
 		}
 	*/
 
-	keyValueList, _ := ConvertKeyValueList(nlbResInfo)
-	retNLBInfo.KeyValueList = keyValueList
+	// keyValueList, _ := ConvertKeyValueList(nlbResInfo)
+	// retNLBInfo.KeyValueList = keyValueList
+
+	// Use irs.StructToKeyValueList to populate KeyValueList
+	retNLBInfo.KeyValueList = irs.StructToKeyValueList(nlbResInfo)
 
 	//==================
 	// VM Group 처리

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/VMHandler.go
@@ -1018,10 +1018,10 @@ func (vmHandler *AwsVMHandler) ExtractDescribeInstanceToVmInfo(instance *ec2.Ins
 		//AdditionalInfo: "State:" + *reservation.Instances[0].State.Name,
 	}
 
-	keyValueList := []irs.KeyValue{
-		{Key: "State", Value: *instance.State.Name},
-		{Key: "Architecture", Value: *instance.Architecture},
-	}
+	// keyValueList := []irs.KeyValue{
+	// 	{Key: "State", Value: *instance.State.Name},
+	// 	{Key: "Architecture", Value: *instance.Architecture},
+	// }
 
 	//if *reservation.Instances[0].LaunchTime != "" {
 	vmInfo.StartTime = *instance.LaunchTime
@@ -1113,11 +1113,11 @@ func (vmHandler *AwsVMHandler) ExtractDescribeInstanceToVmInfo(instance *ec2.Ins
 		if !reflect.ValueOf(instance.NetworkInterfaces[0].VpcId).IsNil() {
 			//vmInfo.VirtualNetworkId = *reservation.Instances[0].NetworkInterfaces[0].VpcId
 			vmInfo.VpcIID = irs.IID{NameId: "", SystemId: *instance.NetworkInterfaces[0].VpcId}
-			keyValueList = append(keyValueList, irs.KeyValue{Key: "VpcId", Value: *instance.NetworkInterfaces[0].VpcId})
+			// keyValueList = append(keyValueList, irs.KeyValue{Key: "VpcId", Value: *instance.NetworkInterfaces[0].VpcId})
 		}
 
 		if !reflect.ValueOf(instance.NetworkInterfaces[0].SubnetId).IsNil() {
-			keyValueList = append(keyValueList, irs.KeyValue{Key: "SubnetId", Value: *instance.NetworkInterfaces[0].SubnetId})
+			// keyValueList = append(keyValueList, irs.KeyValue{Key: "SubnetId", Value: *instance.NetworkInterfaces[0].SubnetId})
 			vmInfo.SubnetIID = irs.IID{SystemId: *instance.NetworkInterfaces[0].SubnetId}
 		}
 
@@ -1157,9 +1157,9 @@ func (vmHandler *AwsVMHandler) ExtractDescribeInstanceToVmInfo(instance *ec2.Ins
 		}
 	*/
 
-	if !reflect.ValueOf(instance.KeyName).IsNil() {
-		keyValueList = append(keyValueList, irs.KeyValue{Key: "KeyName", Value: *instance.KeyName})
-	}
+	// if !reflect.ValueOf(instance.KeyName).IsNil() {
+	// 	keyValueList = append(keyValueList, irs.KeyValue{Key: "KeyName", Value: *instance.KeyName})
+	// }
 
 	if !reflect.ValueOf(instance.Platform).IsNil() {
 		if strings.ToLower(*instance.Platform) == "windows" {
@@ -1168,9 +1168,10 @@ func (vmHandler *AwsVMHandler) ExtractDescribeInstanceToVmInfo(instance *ec2.Ins
 	} else {
 		vmInfo.Platform = irs.LINUX_UNIX
 	}
-	if !reflect.ValueOf(instance.VirtualizationType).IsNil() {
-		keyValueList = append(keyValueList, irs.KeyValue{Key: "VirtualizationType", Value: *instance.VirtualizationType})
-	}
+
+	// if !reflect.ValueOf(instance.VirtualizationType).IsNil() {
+	// 	keyValueList = append(keyValueList, irs.KeyValue{Key: "VirtualizationType", Value: *instance.VirtualizationType})
+	// }
 
 	//Name은 Tag의 "Name" 속성에만 저장됨
 	cblogger.Debug("Name Tag 찾기")
@@ -1182,7 +1183,8 @@ func (vmHandler *AwsVMHandler) ExtractDescribeInstanceToVmInfo(instance *ec2.Ins
 		}
 	}
 
-	vmInfo.KeyValueList = keyValueList
+	// vmInfo.KeyValueList = keyValueList
+	vmInfo.KeyValueList = irs.StructToKeyValueList(instance) // KeyValueList 추가
 	vmInfo.TagList, _ = vmHandler.TagHandler.ListTag(irs.VM, vmInfo.IId)
 	//vmInfo.TagList, _ = GetResourceTag(vmHandler, vmInfo.IId)
 	return vmInfo
@@ -1210,10 +1212,10 @@ func (vmHandler *AwsVMHandler) ExtractDescribeInstances(reservation *ec2.Reserva
 		//AdditionalInfo: "State:" + *reservation.Instances[0].State.Name,
 	}
 
-	keyValueList := []irs.KeyValue{
-		{Key: "State", Value: *reservation.Instances[0].State.Name},
-		{Key: "Architecture", Value: *reservation.Instances[0].Architecture},
-	}
+	// keyValueList := []irs.KeyValue{
+	// 	{Key: "State", Value: *reservation.Instances[0].State.Name},
+	// 	{Key: "Architecture", Value: *reservation.Instances[0].Architecture},
+	// }
 
 	//if *reservation.Instances[0].LaunchTime != "" {
 	vmInfo.StartTime = *reservation.Instances[0].LaunchTime
@@ -1270,11 +1272,11 @@ func (vmHandler *AwsVMHandler) ExtractDescribeInstances(reservation *ec2.Reserva
 		if !reflect.ValueOf(reservation.Instances[0].NetworkInterfaces[0].VpcId).IsNil() {
 			//vmInfo.VirtualNetworkId = *reservation.Instances[0].NetworkInterfaces[0].VpcId
 			vmInfo.VpcIID = irs.IID{"", *reservation.Instances[0].NetworkInterfaces[0].VpcId}
-			keyValueList = append(keyValueList, irs.KeyValue{Key: "VpcId", Value: *reservation.Instances[0].NetworkInterfaces[0].VpcId})
+			// keyValueList = append(keyValueList, irs.KeyValue{Key: "VpcId", Value: *reservation.Instances[0].NetworkInterfaces[0].VpcId})
 		}
 
 		if !reflect.ValueOf(reservation.Instances[0].NetworkInterfaces[0].SubnetId).IsNil() {
-			keyValueList = append(keyValueList, irs.KeyValue{Key: "SubnetId", Value: *reservation.Instances[0].NetworkInterfaces[0].SubnetId})
+			// keyValueList = append(keyValueList, irs.KeyValue{Key: "SubnetId", Value: *reservation.Instances[0].NetworkInterfaces[0].SubnetId})
 			vmInfo.SubnetIID = irs.IID{SystemId: *reservation.Instances[0].NetworkInterfaces[0].SubnetId}
 		}
 
@@ -1322,16 +1324,17 @@ func (vmHandler *AwsVMHandler) ExtractDescribeInstances(reservation *ec2.Reserva
 		}
 	*/
 
-	if !reflect.ValueOf(reservation.Instances[0].KeyName).IsNil() {
-		keyValueList = append(keyValueList, irs.KeyValue{Key: "KeyName", Value: *reservation.Instances[0].KeyName})
-	}
+	// if !reflect.ValueOf(reservation.Instances[0].KeyName).IsNil() {
+	// 	keyValueList = append(keyValueList, irs.KeyValue{Key: "KeyName", Value: *reservation.Instances[0].KeyName})
+	// }
 
-	if !reflect.ValueOf(reservation.Instances[0].Platform).IsNil() {
-		keyValueList = append(keyValueList, irs.KeyValue{Key: "Platform", Value: *reservation.Instances[0].Platform})
-	}
-	if !reflect.ValueOf(reservation.Instances[0].VirtualizationType).IsNil() {
-		keyValueList = append(keyValueList, irs.KeyValue{Key: "VirtualizationType", Value: *reservation.Instances[0].VirtualizationType})
-	}
+	// if !reflect.ValueOf(reservation.Instances[0].Platform).IsNil() {
+	// 	keyValueList = append(keyValueList, irs.KeyValue{Key: "Platform", Value: *reservation.Instances[0].Platform})
+	// }
+
+	// if !reflect.ValueOf(reservation.Instances[0].VirtualizationType).IsNil() {
+	// 	keyValueList = append(keyValueList, irs.KeyValue{Key: "VirtualizationType", Value: *reservation.Instances[0].VirtualizationType})
+	// }
 
 	//Name은 Tag의 "Name" 속성에만 저장됨
 	cblogger.Debug("Name Tag Search")
@@ -1343,7 +1346,8 @@ func (vmHandler *AwsVMHandler) ExtractDescribeInstances(reservation *ec2.Reserva
 		}
 	}
 
-	vmInfo.KeyValueList = keyValueList
+	// vmInfo.KeyValueList = keyValueList
+	vmInfo.KeyValueList = irs.StructToKeyValueList(reservation.Instances[0]) // KeyValueList 추가
 	return vmInfo
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/VPCHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/VPCHandler.go
@@ -14,7 +14,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -570,6 +569,8 @@ func ExtractVpcDescribeInfo(vpcInfo *ec2.Vpc) irs.VPCInfo {
 		}
 	}
 
+	awsVpcInfo.KeyValueList = irs.StructToKeyValueList(vpcInfo)
+
 	return awsVpcInfo
 }
 
@@ -1092,14 +1093,15 @@ func ExtractSubnetDescribeInfo(subnetInfo *ec2.Subnet) irs.SubnetInfo {
 		}
 	*/
 
-	keyValueList := []irs.KeyValue{
-		{Key: "VpcId", Value: *subnetInfo.VpcId},
-		{Key: "MapPublicIpOnLaunch", Value: strconv.FormatBool(*subnetInfo.MapPublicIpOnLaunch)},
-		{Key: "AvailableIpAddressCount", Value: strconv.FormatInt(*subnetInfo.AvailableIpAddressCount, 10)},
-		{Key: "AvailabilityZone", Value: *subnetInfo.AvailabilityZone},
-		{Key: "Status", Value: *subnetInfo.State},
-	}
-	vNetworkInfo.KeyValueList = keyValueList
+	// keyValueList := []irs.KeyValue{
+	// 	{Key: "VpcId", Value: *subnetInfo.VpcId},
+	// 	{Key: "MapPublicIpOnLaunch", Value: strconv.FormatBool(*subnetInfo.MapPublicIpOnLaunch)},
+	// 	{Key: "AvailableIpAddressCount", Value: strconv.FormatInt(*subnetInfo.AvailableIpAddressCount, 10)},
+	// 	{Key: "AvailabilityZone", Value: *subnetInfo.AvailabilityZone},
+	// 	{Key: "Status", Value: *subnetInfo.State},
+	// }
+	// vNetworkInfo.KeyValueList = keyValueList
+	vNetworkInfo.KeyValueList = irs.StructToKeyValueList(subnetInfo)
 
 	return vNetworkInfo
 }

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/ClusterHandler.go
@@ -1111,6 +1111,8 @@ func mappingClusterInfo(cluster *container.Cluster) (ClusterInfo irs.ClusterInfo
 	clusterInfo.CreatedTime = createDatetime
 	clusterInfo.Addons = addOnsInfo
 
+	// 2025-03-13 StructToKeyValueList 사용으로 변경
+	clusterInfo.KeyValueList = irs.StructToKeyValueList(cluster)
 	// cblogger.Debug(clusterInfo)
 
 	return clusterInfo, nil
@@ -1146,7 +1148,9 @@ func mappingNodeGroupInfo(nodePool *container.NodePool) (NodeGroupInfo irs.NodeG
 	nodeGroupInfo.RootDiskSize = strconv.FormatInt(nodePool.Config.DiskSizeGb, 10)
 	nodeGroupInfo.RootDiskType = nodePool.Config.DiskType
 
-	keyValueList := []irs.KeyValue{}
+	// 2025-03-13 StructToKeyValueList 사용으로 변경. InstanceGroup_idx 와 GCP_PMKS_KEYPAIR_KEY 는 살려둠
+	keyValueList := irs.StructToKeyValueList(nodePool)
+
 	if nodePool.InstanceGroupUrls != nil {
 		for idx, instanceGroupUrl := range nodePool.InstanceGroupUrls {
 			urlArr := strings.Split(instanceGroupUrl, "/")
@@ -1156,7 +1160,6 @@ func mappingNodeGroupInfo(nodePool *container.NodePool) (NodeGroupInfo irs.NodeG
 			// InstanceGroup.ListInstances
 			//"instance": "https://www.googleapis.com/compute/v1/projects/csta-349809/zones/asia-northeast1-a/instances/gke-spider-cluster-03-ce-default-pool-3082fa6f-kvks",
 		}
-
 	}
 
 	// add keypair label
@@ -1167,8 +1170,8 @@ func mappingNodeGroupInfo(nodePool *container.NodePool) (NodeGroupInfo irs.NodeG
 			}
 		}
 	}
-
 	nodeGroupInfo.KeyValueList = keyValueList
+	// nodeGroupInfo.KeyValueList = keyValueList
 
 	return nodeGroupInfo, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/DiskHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/DiskHandler.go
@@ -537,6 +537,9 @@ func convertDiskInfo(diskResp *compute.Disk) (irs.DiskInfo, error) {
 	}
 	diskInfo.TagList = tags
 
+	// 2025-03-13 StructToKeyValueList 사용으로 변경
+	diskInfo.KeyValueList = irs.StructToKeyValueList(diskResp)
+
 	return diskInfo, nil
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/KeyPairHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/KeyPairHandler.go
@@ -95,14 +95,21 @@ func (keyPairHandler *GCPKeyPairHandler) CreateKey(keyPairReqInfo irs.KeyPairReq
 
 	publicKeyString := string(publicKeyBytes)
 	publicKeyString = strings.TrimSpace(publicKeyString) + " " + "cb-user"
+	// keyPairInfo := irs.KeyPairInfo{
+	// 	IId: irs.IID{
+	// 		NameId:   keyPairName,
+	// 		SystemId: keyPairName,
+	// 	},
+	// 	PublicKey:  publicKeyString,
+	// 	PrivateKey: string(privateKeyBytes),
+	// }
 
-	keyPairInfo := irs.KeyPairInfo{
-		IId: irs.IID{
-			NameId:   keyPairName,
-			SystemId: keyPairName,
-		},
-		PublicKey:  publicKeyString,
-		PrivateKey: string(privateKeyBytes),
+	keyPairInfo, err := keyPairHandler.GetKey(irs.IID{SystemId: keyPairName})
+	if err != nil {
+		cblogger.Error("Fail GetKey")
+		cblogger.Error(err)
+		cblogger.Infof("publicKeyString : [%s]", publicKeyString)
+		return irs.KeyPairInfo{}, err
 	}
 	return keyPairInfo, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/MyImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/MyImageHandler.go
@@ -154,6 +154,9 @@ func (MyImageHandler *GCPMyImageHandler) convertMyImageInfo(myImageResp *compute
 
 	myImageInfo.CreatedTime, _ = time.Parse(time.RFC3339, myImageResp.CreationTimestamp)
 
+	// 2025-03-13 StructToKeyValueList 사용으로 변경
+	myImageInfo.KeyValueList = irs.StructToKeyValueList(myImageResp)
+
 	return myImageInfo, nil
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/NLBHandler.go
@@ -2814,6 +2814,9 @@ func convertRegionForwardingRuleToNlbListener(forwardingRule *compute.Forwarding
 		CspID: forwardingRule.Name, // forwarding rule name 전체
 		//KeyValueList:
 	}
+
+	// 2025-03-13 StructToKeyValueList 사용으로 변경
+	listenerInfo.KeyValueList = irs.StructToKeyValueList(forwardingRule)
 	return listenerInfo
 }
 
@@ -2857,12 +2860,12 @@ func (nlbHandler *GCPNLBHandler) getListenerByNlbSystemID(nlbIID irs.IID) (irs.L
 			loadBalancerType = SPIDER_LoadBalancerType_PUBLIC
 		}
 
-		createTimeKeyValue := irs.KeyValue{Key: "createdTime", Value: regionForwardingRule.CreationTimestamp}
-		loadBalancerTypeKeyValue := irs.KeyValue{Key: "loadBalancerType", Value: loadBalancerType}
-		keyValueList := []irs.KeyValue{}
-		keyValueList = append(keyValueList, createTimeKeyValue)
-		keyValueList = append(keyValueList, loadBalancerTypeKeyValue)
-		listenerInfo.KeyValueList = keyValueList
+		// createTimeKeyValue := irs.KeyValue{Key: "createdTime", Value: regionForwardingRule.CreationTimestamp}
+		// loadBalancerTypeKeyValue := irs.KeyValue{Key: "loadBalancerType", Value: loadBalancerType}
+		// keyValueList := []irs.KeyValue{}
+		// keyValueList = append(keyValueList, createTimeKeyValue)
+		// keyValueList = append(keyValueList, loadBalancerTypeKeyValue)
+		// listenerInfo.KeyValueList = keyValueList
 	}
 
 	return listenerInfo, nil
@@ -2907,6 +2910,9 @@ func extractVmGroup(targetPool *compute.TargetPool, nlbInfo *irs.NLBInfo) irs.VM
 		//네트워크 부하 분산기는 전송 계층 보안(TLS) 오프로드 또는 프록시를 수행하지 않습니다. 트래픽은 VM으로 직접 라우팅됩니다.
 		vmGroup.CspID = targetPool.Name
 		vmGroup.VMs = &instanceIIDs
+
+		// 2025-03-13 StructToKeyValueList 사용으로 변경
+		vmGroup.KeyValueList = irs.StructToKeyValueList(targetPool.Instances)
 	}
 	return vmGroup
 }
@@ -2952,7 +2958,8 @@ func (nlbHandler *GCPNLBHandler) extractHealthChecker(regionID string, targetPoo
 			}
 			cblogger.Info("GlobalHttpHealthChecks end: ")
 		}
-
+		// 2025-03-13 StructToKeyValueList 사용으로 변경
+		returnHealthChecker.KeyValueList = irs.StructToKeyValueList(targetPool.HealthChecks)
 	}
 	return returnHealthChecker, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/SecurityHandler.go
@@ -1678,18 +1678,20 @@ func convertFromFirewallToSecurityInfo(firewallList compute.FirewallList) (irs.S
 			},
 
 			// Direction: security.Direction,
-			KeyValueList: []irs.KeyValue{
-				{Key: "Priority", Value: strconv.FormatInt(item.Priority, 10)},
-				// {"SourceRanges", security.SourceRanges[0]},
-				{Key: "Allowed", Value: ipProtocol},
-				{Key: "Vpc", Value: vpcName},
-			},
+			// KeyValueList: []irs.KeyValue{
+			// 	{Key: "Priority", Value: strconv.FormatInt(item.Priority, 10)},
+			// 	// {"SourceRanges", security.SourceRanges[0]},
+			// 	{Key: "Allowed", Value: ipProtocol},
+			// 	{Key: "Vpc", Value: vpcName},
+			// },
 			SecurityRules: &securityRules,
 		}
 		cblogger.Info("securityRules : ", securityRules)
 		cblogger.Info("securityRules length: ", len(securityRules))
 	} // end of result.items
 	cblogger.Info("securityInfo : ", securityInfo)
+	//2025-03-13 StructToKeyValueList 사용으로 변경
+	securityInfo.KeyValueList = irs.StructToKeyValueList(firewallList)
 	return securityInfo, nil
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/VMHandler.go
@@ -1260,16 +1260,16 @@ func (vmHandler *GCPVMHandler) mappingServerInfo(server *compute.Instance) irs.V
 		RootDiskSize:   strconv.FormatInt(diskInfo.SizeGb, 10),
 		RootDeviceName: server.Disks[0].DeviceName,
 		DataDiskIIDs:   attachedDisk.Items,
-		KeyValueList: []irs.KeyValue{
-			{"SubNetwork", server.NetworkInterfaces[0].Subnetwork},
-			{"AccessConfigName", server.NetworkInterfaces[0].AccessConfigs[0].Name},
-			{"NetworkTier", server.NetworkInterfaces[0].AccessConfigs[0].NetworkTier},
-			{"DiskDeviceName", server.Disks[0].DeviceName},
-			{"DiskName", server.Disks[0].Source},
+		// KeyValueList: []irs.KeyValue{
+		// 	{"SubNetwork", server.NetworkInterfaces[0].Subnetwork},
+		// 	{"AccessConfigName", server.NetworkInterfaces[0].AccessConfigs[0].Name},
+		// 	{"NetworkTier", server.NetworkInterfaces[0].AccessConfigs[0].NetworkTier},
+		// 	{"DiskDeviceName", server.Disks[0].DeviceName},
+		// 	{"DiskName", server.Disks[0].Source},
 
-			{"Kind", server.Kind},
-			{"ZoneUrl", server.Zone},
-		},
+		// 	{"Kind", server.Kind},
+		// 	{"ZoneUrl", server.Zone},
+		// },
 	}
 
 	vmInfo.ImageType = vmHandler.getImageType(server.SourceMachineImage)
@@ -1312,6 +1312,8 @@ func (vmHandler *GCPVMHandler) mappingServerInfo(server *compute.Instance) irs.V
 	}
 	vmInfo.TagList = tags
 
+	// 2025-03-13 StructToKeyValueList 사용으로 변경
+	vmInfo.KeyValueList = irs.StructToKeyValueList(server)
 	return vmInfo
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/VPCHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/VPCHandler.go
@@ -464,22 +464,23 @@ func (vVPCHandler *GCPVPCHandler) GetVPC(vpcIID irs.IID) (irs.VPCInfo, error) {
 		},
 		IPv4_CIDR:      "GCP VPC does not support IPv4_CIDR",
 		SubnetInfoList: subnetInfoList,
-		KeyValueList: []irs.KeyValue{
-			{"RoutingMode", infoVPC.RoutingConfig.RoutingMode},
-			{"Description", infoVPC.Description},
-			{"SelfLink", infoVPC.SelfLink},
-		},
+		// KeyValueList: []irs.KeyValue{
+		// 	{"RoutingMode", infoVPC.RoutingConfig.RoutingMode},
+		// 	{"Description", infoVPC.Description},
+		// 	{"SelfLink", infoVPC.SelfLink},
+		// },
 	}
-
+	// 2025-03-13 StructToKeyValueList 사용으로 변경
+	networkInfo.KeyValueList = irs.StructToKeyValueList(infoVPC)
 	return networkInfo, nil
 }
 
 func mappingSubnet(subnet *compute.Subnetwork) irs.SubnetInfo {
 	//str := subnet.SelfLink
-	str := strings.Split(subnet.SelfLink, "/")
-	subnetName := str[len(str)-1]
-	regionStr := strings.Split(subnet.Region, "/")
-	region := regionStr[len(regionStr)-1]
+	//str := strings.Split(subnet.SelfLink, "/")
+	//subnetName := str[len(str)-1]
+	//regionStr := strings.Split(subnet.Region, "/")
+	//region := regionStr[len(regionStr)-1]
 	subnetInfo := irs.SubnetInfo{
 		IId: irs.IID{
 			NameId: subnet.Name,
@@ -487,11 +488,14 @@ func mappingSubnet(subnet *compute.Subnetwork) irs.SubnetInfo {
 			SystemId: subnet.Name,
 		},
 		IPv4_CIDR: subnet.IpCidrRange,
-		KeyValueList: []irs.KeyValue{
-			{"region", region},
-			{"subnet", subnetName},
-		},
+		// KeyValueList: []irs.KeyValue{
+		// 	{"region", region},
+		// 	{"subnet", subnetName},
+		// },
 	}
+
+	// 2025-03-13 StructToKeyValueList 사용으로 변경
+	subnetInfo.KeyValueList = irs.StructToKeyValueList(subnet)
 	return subnetInfo
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/ClusterHandler.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/tencent/utils/tencent"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
 	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
-	"github.com/jeremywohl/flatten"
 
 	tke "github.com/tencentcloud/tencentcloud-sdk-go-intl-en/tencentcloud/tke/v20180525"
 	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common"
@@ -497,27 +496,30 @@ func getClusterInfo(access_key string, access_secret string, region_id string, c
 			clusterInfo.TagList = tagList
 		}
 	}
+
+	// 2025-03-13 StructToKeyValueList 사용으로 변경
+	clusterInfo.KeyValueList = irs.StructToKeyValueList(res.Response.Clusters[0])
 	// k,v 추출 & 추가
 	// KeyValueList: []irs.KeyValue{}, // flatten data 입력하기
-	temp, err := json.Marshal(*res.Response.Clusters[0])
-	if err != nil {
-		err := fmt.Errorf("Failed to Marshal Cluster Info :  %v", err)
-		cblogger.Error(err)
-		panic(err)
-	}
-	var json_obj map[string]interface{}
-	json.Unmarshal([]byte(temp), &json_obj)
+	// temp, err := json.Marshal(*res.Response.Clusters[0])
+	// if err != nil {
+	// 	err := fmt.Errorf("Failed to Marshal Cluster Info :  %v", err)
+	// 	cblogger.Error(err)
+	// 	panic(err)
+	// }
+	// var json_obj map[string]interface{}
+	// json.Unmarshal([]byte(temp), &json_obj)
 
-	flat, err := flatten.Flatten(json_obj, "", flatten.DotStyle)
-	if err != nil {
-		err := fmt.Errorf("Failed to Flatten Cluster Info :  %v", err)
-		cblogger.Error(err)
-		return nil, err
-	}
-	for k, v := range flat {
-		temp := fmt.Sprintf("%v", v)
-		clusterInfo.KeyValueList = append(clusterInfo.KeyValueList, irs.KeyValue{Key: k, Value: temp})
-	}
+	// flat, err := flatten.Flatten(json_obj, "", flatten.DotStyle)
+	// if err != nil {
+	// 	err := fmt.Errorf("Failed to Flatten Cluster Info :  %v", err)
+	// 	cblogger.Error(err)
+	// 	return nil, err
+	// }
+	// for k, v := range flat {
+	// 	temp := fmt.Sprintf("%v", v)
+	// 	clusterInfo.KeyValueList = append(clusterInfo.KeyValueList, irs.KeyValue{Key: k, Value: temp})
+	// }
 
 	// NodeGroups
 	res2, err := tencent.ListNodeGroup(access_key, access_secret, region_id, cluster_id)
@@ -734,25 +736,27 @@ func getNodeGroupInfo(access_key, access_secret, region_id, cluster_id, node_gro
 		}
 	}
 
+	// 2025-03-13 StructToKeyValueList 사용으로 변경
+	nodeGroupInfo.KeyValueList = irs.StructToKeyValueList(res.Response.NodePool)
 	// add key value list
-	temp, err := json.Marshal(*res.Response.NodePool)
-	if err != nil {
-		err := fmt.Errorf("Failed to Marshal NodeGroup Info :  %v", err)
-		cblogger.Error(err)
-		panic(err)
-	}
-	var json_obj map[string]interface{}
-	json.Unmarshal([]byte(temp), &json_obj)
-	flat, err := flatten.Flatten(json_obj, "", flatten.DotStyle)
-	if err != nil {
-		err := fmt.Errorf("Failed to Flatten NodeGroup Info :  %v", err)
-		cblogger.Error(err)
-		return nil, err
-	}
-	for k, v := range flat {
-		temp := fmt.Sprintf("%v", v)
-		nodeGroupInfo.KeyValueList = append(nodeGroupInfo.KeyValueList, irs.KeyValue{Key: k, Value: temp})
-	}
+	// temp, err := json.Marshal(*res.Response.NodePool)
+	// if err != nil {
+	// 	err := fmt.Errorf("Failed to Marshal NodeGroup Info :  %v", err)
+	// 	cblogger.Error(err)
+	// 	panic(err)
+	// }
+	// var json_obj map[string]interface{}
+	// json.Unmarshal([]byte(temp), &json_obj)
+	// flat, err := flatten.Flatten(json_obj, "", flatten.DotStyle)
+	// if err != nil {
+	// 	err := fmt.Errorf("Failed to Flatten NodeGroup Info :  %v", err)
+	// 	cblogger.Error(err)
+	// 	return nil, err
+	// }
+	// for k, v := range flat {
+	// 	temp := fmt.Sprintf("%v", v)
+	// 	nodeGroupInfo.KeyValueList = append(nodeGroupInfo.KeyValueList, irs.KeyValue{Key: k, Value: temp})
+	// }
 
 	return nodeGroupInfo, err
 }

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/DiskHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/DiskHandler.go
@@ -280,6 +280,8 @@ func convertDiskInfo(diskResp *cbs.Disk) (irs.DiskInfo, error) {
 		}
 	}
 
+	// 2025-03-13 StructToKeyValueList 사용으로 변경
+	diskInfo.KeyValueList = irs.StructToKeyValueList(diskResp)
 	return diskInfo, nil
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/KeyPairHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/KeyPairHandler.go
@@ -119,12 +119,14 @@ func ExtractKeyPairDescribeInfo(keyPair *cvm.KeyPair) (irs.KeyPairInfo, error) {
 	keyPairInfo.PublicKey = string(publicKeyBytes)
 	keyPairInfo.PrivateKey = string(privateKeyBytes)
 	*/
-	keyValueList := []irs.KeyValue{
-		{Key: "KeyId", Value: *keyPair.KeyId},
-		//{Key: "KeyMaterial", Value: *keyPair.KeyMaterial},
-	}
+	// 2025-03-13 StructToKeyValueList 사용으로 변경
+	keyPairInfo.KeyValueList = irs.StructToKeyValueList(keyPair)
+	// keyValueList := []irs.KeyValue{
+	// 	{Key: "KeyId", Value: *keyPair.KeyId},
+	// 	//{Key: "KeyMaterial", Value: *keyPair.KeyMaterial},
+	// }
 
-	keyPairInfo.KeyValueList = keyValueList
+	// keyPairInfo.KeyValueList = keyValueList
 
 	return keyPairInfo, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/MyImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/MyImageHandler.go
@@ -287,6 +287,8 @@ func convertImageSetToMyImageInfo(tencentImage *cvm.Image) (irs.MyImageInfo, err
 		returnMyImageInfo.TagList = tagList
 	}
 
+	// 2025-03-13 StructToKeyValueList 사용으로 변경
+	returnMyImageInfo.KeyValueList = irs.StructToKeyValueList(tencentImage)
 	return returnMyImageInfo, nil
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/NLBHandler.go
@@ -939,7 +939,8 @@ func (NLBHandler *TencentNLBHandler) ExtractNLBDescribeInfo(nlbInfo *clb.LoadBal
 		}
 		resNLBInfo.TagList = tagList
 	}
-
+	// 2025-03-13 StructToKeyValueList 사용으로 변경
+	resNLBInfo.KeyValueList = irs.StructToKeyValueList(nlbInfo)
 	return resNLBInfo, nil
 }
 
@@ -974,6 +975,9 @@ func (NLBHandler *TencentNLBHandler) ExtractListenerInfo(nlbIID irs.IID) (irs.Li
 		return irs.ListenerInfo{}, ipErr
 	}
 	resListenerInfo.IP = *ipResponse.Response.LoadBalancerSet[0].LoadBalancerVips[0]
+
+	// 2025-03-13 StructToKeyValueList 사용으로 변경
+	resListenerInfo.KeyValueList = irs.StructToKeyValueList(ipResponse.Response.LoadBalancerSet[0])
 
 	return resListenerInfo, nil
 }
@@ -1049,8 +1053,9 @@ func (NLBHandler *TencentNLBHandler) ExtractHealthCheckerInfo(nlbIID irs.IID) (i
 	if tencentHealthCheck.CheckPort != nil {
 		resHealthCheckerInfo.Port = strconv.FormatInt(*tencentHealthCheck.CheckPort, 10)
 	}
-	cblogger.Debug("after")
 
+	// 2025-03-13 StructToKeyValueList 사용으로 변경
+	resHealthCheckerInfo.KeyValueList = irs.StructToKeyValueList(tencentHealthCheck)
 	return resHealthCheckerInfo, nil
 
 }

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/SecurityHandler.go
@@ -322,6 +322,9 @@ func (securityHandler *TencentSecurityHandler) GetSecurity(securityIID irs.IID) 
 			cblogger.Error(err)
 			return irs.SecurityInfo{}, err
 		}
+
+		// 2025-03-13 StructToKeyValueList 사용으로 변경
+		securityInfo.KeyValueList = irs.StructToKeyValueList(response.Response.SecurityGroupSet)
 		return securityInfo, nil
 	} else {
 		return irs.SecurityInfo{}, errors.New("InvalidSecurityGroupId.NotFound: The SecurityGroup " + securityIID.SystemId + " does not exist")

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/VMHandler.go
@@ -778,15 +778,15 @@ func (vmHandler *TencentVMHandler) ExtractDescribeInstances(curVm *cvm.Instance)
 		vmInfo.TagList = tagList
 	}
 
-	keyValueList := []irs.KeyValue{
-		{Key: "InstanceState", Value: *curVm.InstanceState},
-		{Key: "OsName", Value: *curVm.OsName},
-	}
+	// keyValueList := []irs.KeyValue{
+	// 	{Key: "InstanceState", Value: *curVm.InstanceState},
+	// 	{Key: "OsName", Value: *curVm.OsName},
+	// }
 
 	//요금타입
-	if !reflect.ValueOf(curVm.InstanceChargeType).IsNil() {
-		keyValueList = append(keyValueList, irs.KeyValue{Key: "InstanceChargeType", Value: *curVm.InstanceChargeType})
-	}
+	// if !reflect.ValueOf(curVm.InstanceChargeType).IsNil() {
+	// 	keyValueList = append(keyValueList, irs.KeyValue{Key: "InstanceChargeType", Value: *curVm.InstanceChargeType})
+	// }
 
 	//데이터 디스크 정보
 	if !reflect.ValueOf(curVm.DataDisks).IsNil() {
@@ -804,30 +804,32 @@ func (vmHandler *TencentVMHandler) ExtractDescribeInstances(curVm *cvm.Instance)
 	//시스템 디스크 정보
 	if !reflect.ValueOf(curVm.SystemDisk).IsNil() {
 		if !reflect.ValueOf(curVm.SystemDisk.DiskType).IsNil() {
-			keyValueList = append(keyValueList, irs.KeyValue{Key: "SystemDiskType", Value: *curVm.SystemDisk.DiskType})
+			//keyValueList = append(keyValueList, irs.KeyValue{Key: "SystemDiskType", Value: *curVm.SystemDisk.DiskType})
 			vmInfo.RootDiskType = *curVm.SystemDisk.DiskType
 		}
 		if !reflect.ValueOf(curVm.SystemDisk.DiskId).IsNil() {
-			keyValueList = append(keyValueList, irs.KeyValue{Key: "SystemDiskId", Value: *curVm.SystemDisk.DiskId})
+			//keyValueList = append(keyValueList, irs.KeyValue{Key: "SystemDiskId", Value: *curVm.SystemDisk.DiskId})
 			vmInfo.VMBootDisk = *curVm.SystemDisk.DiskId
 			vmInfo.RootDeviceName = *curVm.SystemDisk.DiskId
 		}
 		if !reflect.ValueOf(curVm.SystemDisk.DiskSize).IsNil() {
-			keyValueList = append(keyValueList, irs.KeyValue{Key: "SystemDiskSize", Value: strconv.FormatInt(*curVm.SystemDisk.DiskSize, 10)})
+			//keyValueList = append(keyValueList, irs.KeyValue{Key: "SystemDiskSize", Value: strconv.FormatInt(*curVm.SystemDisk.DiskSize, 10)})
 			vmInfo.RootDiskSize = strconv.FormatInt(*curVm.SystemDisk.DiskSize, 10)
 		}
 	}
 
-	if !reflect.ValueOf(curVm.InternetAccessible).IsNil() {
-		if !reflect.ValueOf(curVm.InternetAccessible.InternetChargeType).IsNil() {
-			keyValueList = append(keyValueList, irs.KeyValue{Key: "InternetChargeType", Value: *curVm.InternetAccessible.InternetChargeType})
-		}
-		if !reflect.ValueOf(curVm.InternetAccessible.InternetMaxBandwidthOut).IsNil() {
-			keyValueList = append(keyValueList, irs.KeyValue{Key: "InternetMaxBandwidthOut", Value: strconv.FormatInt(*curVm.InternetAccessible.InternetMaxBandwidthOut, 10)})
-		}
-	}
+	// if !reflect.ValueOf(curVm.InternetAccessible).IsNil() {
+	// 	if !reflect.ValueOf(curVm.InternetAccessible.InternetChargeType).IsNil() {
+	// 		//keyValueList = append(keyValueList, irs.KeyValue{Key: "InternetChargeType", Value: *curVm.InternetAccessible.InternetChargeType})
+	// 	}
+	// 	if !reflect.ValueOf(curVm.InternetAccessible.InternetMaxBandwidthOut).IsNil() {
+	// 		//keyValueList = append(keyValueList, irs.KeyValue{Key: "InternetMaxBandwidthOut", Value: strconv.FormatInt(*curVm.InternetAccessible.InternetMaxBandwidthOut, 10)})
+	// 	}
+	// }
 
-	vmInfo.KeyValueList = keyValueList
+	// 2025-03-13 StructToKeyValueList 사용으로 변경
+	vmInfo.KeyValueList = irs.StructToKeyValueList(curVm)
+	// vmInfo.KeyValueList = keyValueList
 
 	return vmInfo, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/VPCHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/VPCHandler.go
@@ -12,7 +12,6 @@ package resources
 
 import (
 	"errors"
-	"strconv"
 
 	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
@@ -160,6 +159,8 @@ func ExtractVpcDescribeInfo(vpcInfo *vpc.Vpc) irs.VPCInfo {
 		resVpcInfo.TagList = tagList
 	}
 
+	// 2025-03-13 StructToKeyValueList 사용으로 변경
+	resVpcInfo.KeyValueList = irs.StructToKeyValueList(vpcInfo)
 	return resVpcInfo
 }
 
@@ -384,12 +385,14 @@ func (VPCHandler *TencentVPCHandler) ListSubnet(reqVpcId string) ([]irs.SubnetIn
 			resSubnetInfo.TagList = tagList
 		}
 
-		keyValueList := []irs.KeyValue{
-			{Key: "VpcId", Value: *curSubnet.VpcId},
-			{Key: "IsDefault", Value: strconv.FormatBool(*curSubnet.IsDefault)},
-			{Key: "AvailabilityZone", Value: *curSubnet.Zone},
-		}
-		resSubnetInfo.KeyValueList = keyValueList
+		// 2025-03-13 StructToKeyValueList 사용으로 변경
+		resSubnetInfo.KeyValueList = irs.StructToKeyValueList(curSubnet)
+		// keyValueList := []irs.KeyValue{
+		// 	{Key: "VpcId", Value: *curSubnet.VpcId},
+		// 	{Key: "IsDefault", Value: strconv.FormatBool(*curSubnet.IsDefault)},
+		// 	{Key: "AvailabilityZone", Value: *curSubnet.Zone},
+		// }
+		// resSubnetInfo.KeyValueList = keyValueList
 		arrSubnetInfoList = append(arrSubnetInfoList, resSubnetInfo)
 	}
 


### PR DESCRIPTION
set KeyValueList 

|       | Provider | VPC(Create, List, Get, AddSubnet) | SecurityGroup(Create, List, Get, AddRules) | VM KeyPair(Create, List, Get) | VM(Start, List, Get) | Disk(Start, List, Get, Attach) | MyImage(Snapshot, List, Get) | NLB(Create, List, Get, GetVMGroupHealthInfo, AddVMs, ListenerInfo, VMGroupInfo, HealthCheckerInfo) | Cluster(Create, List, Get, AddNodeGroup, ChangeNodeGroupScaling, UpgradeCluster) | 기타 / 특이사항 |
|-------|----------|-----------------------------------|---------------------------------------------|-------------------------------|---------------------|--------------------------------|------------------------------|------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------|----------------|
|       | AWS      | O                                 | O                                           | O                             | O                   | O                              | O                            | Create: O, List: O, Get: O, GetVMGroupHealthInfo: keyvalue 없음, AddVMs: O, ListenerInfo: O, VMGroupInfo: O, HealthCheckerInfo: O | O                                                                                                                |                |
|       | GCP      | O                                 | O                                           | -                             | O                   | O                              | O                            | Create: -, List: -, Get: -, GetVMGroupHealthInfo: - (keyvalue 없음), AddVMs: -, ListenerInfo: O, VMGroupInfo: - (vm에 대한 iid만 set 하고 있어 추가하지 않음), HealthCheckerInfo: O | Create: O, List: O, Get: O, AddNodeGroup: O, ChangeNodeGroupScaling: O, UpgradeCluster: O                        | GCP의 KeyPair는 DB에서 조회하여 key/value로 해당 Struct를 생성하여 keyvalueList를 set하지 않음. |
|       | Alibaba  | O                                 | O                                           | O                             | O                   | O                              | O                            | Create: O, List: O, Get: O, GetVMGroupHealthInfo: - (keyvalue 없음), AddVMs: O, ListenerInfo: - (nlb에 있는 내용이라 추가하지 않음), VMGroupInfo: - (vm에 대한 iid만 set 하고 있어 추가하지 않음), HealthCheckerInfo: O | Create (Cluster only): O, List: O, Get: O, AddNodeGroup: O, ChangeNodeGroupScaling: O, UpgradeCluster: O         | 생성시: Cluster 만 생성 따로, NodeGroup 생성 따로. |
|       | Tencent   | O                                 | X                                           | O                             | O                   | O                              | O                            | Create: O, List: O, Get: O, GetVMGroupHealthInfo: X, AddVMs: O, ListenerInfo: O, VMGroupInfo: X, HealthCheckerInfo: O | O                                                                                                                |                |